### PR TITLE
Parameterized  address and port for grpc server to listen

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,15 @@
     5.2 [Add new gRPC function](#add_new_grpc_function)
 
 6. [Limitations of the current implementation](#limitation)
-  
+
 **<a id="introduction">1. Introduction</a>**
 
   This repository is a part of [MindWM](https://github.com/metacoma/mindwm) projects and contains:
 
   [Freeplane plugin grpc](https://github.com/metacoma/freeplane_plugin_grpc/tree/main/src/main/java/org/freeplane/plugin/grpc)
 
-  The Freeplane plugin for gRPC allows you to start a gRPC server within a running instance of Freeplane. The gRCP server listens on port 50051 and waits for gRPC calls from clients
+  The Freeplane plugin for gRPC allows you to start a gRPC server within a running instance of Freeplane. By default, the gRPC server listens on port 50051 and waits for gRPC calls from clients. You can change this behavior by specifying the `GRPC_LISTEN_ADDR` and `GRPC_LISTEN_PORT` environment variables.
+
 
   [Protobuf file](https://github.com/metacoma/freeplane_plugin_grpc/blob/ca8f667a0f373506c579762c92ffd954ca1827c7/src/main/proto/freeplane.proto)
 
@@ -46,9 +47,9 @@
 
 ![image](https://developer.token.io/token_rest_api_doc/content/resources/images/grpc-proto_concept.png)
 
-gRPC is a high-performance, open-source framework for building remote procedure call (RPC) APIs. 
-It uses the Protocol Buffers data serialization format and supports a variety of programming languages. 
-The main goals of gRPC are to provide a high-performance, efficient, and low-latency way to create scalable, distributed systems. 
+gRPC is a high-performance, open-source framework for building remote procedure call (RPC) APIs.
+It uses the Protocol Buffers data serialization format and supports a variety of programming languages.
+The main goals of gRPC are to provide a high-performance, efficient, and low-latency way to create scalable, distributed systems.
 
 With freeplane_grpc_plugin you can use your preferred programming language to enhance/extend the functionality of Freeplane, here is a list of programming languages that support gRPC, along with gRPC tutorial links.
 
@@ -85,41 +86,41 @@ With freeplane_grpc_plugin you can use your preferred programming language to en
 ![image](https://camo.githubusercontent.com/cc146572f14629e0a4fc2f834a61240b16b522c4e7775ae186b029c49d497ca1/68747470733a2f2f7261772e6769746875622e636f6d2f4d6174742d44656163616c696f6e2f506f6d6f646f726f2d43616c63756c61746f722f6d61737465722f73637265656e73686f742e706e67)
 
   The following ruby script helps me to visualize the pomodoro sessions in mindmap as mindmap nodes.
-  
+
 
 ```bash
 # install required gRPC ruby dependenices https://grpc.io/docs/languages/ruby/quickstart/
-$ gem install grpc 
+$ gem install grpc
 $ gem install grpc-tools
 # clone this repo
-$ git clone https://github.com/metacoma/freeplane_plugin_grpc 
+$ git clone https://github.com/metacoma/freeplane_plugin_grpc
 # run Freeplane with installed freeplane_plugin_grpc
 $ ~/freeplane/BIN/freeplane.sh &
 $ cd grpc/ruby
 # if you have installed get-pomodori
-$ get-pomodori --from=08:00:00 --break=5 --long-break=26 --amount 16 --json | ruby ./pomodoro.rb 
+$ get-pomodori --from=08:00:00 --break=5 --long-break=26 --amount 16 --json | ruby ./pomodoro.rb
 # if you don't have get-pomodori, you can use example json data
 $ cat pomodori_example_data.json | ruby ./pomodoro.rb
 ```
 ![ruby_example](https://user-images.githubusercontent.com/5146707/215350355-4e98b3db-fff1-4506-bb89-b3337e056ff8.gif)
 
 **<a id="example_python">3.2 Python example</a>**
-  
+
 This example demonstrates how you can visualize and create a mind map for a list of Amazon EC2 virtual machines.
 
 ```bash
 # install required gRPC python dependencies https://grpc.io/docs/languages/python/quickstart/
 # you need python 3.7 or higher and pip 9.0.1 or higher
 $ python -m pip install grpcio
-$ python -m pip install grpcio-tools 
+$ python -m pip install grpcio-tools
 # run Freeplane with installed freeplane_plugin_grpc
 $ ~/freeplane/BIN/freeplane.sh &
-$ git clone https://github.com/metacoma/freeplane_plugin_grpc 
+$ git clone https://github.com/metacoma/freeplane_plugin_grpc
 $ cd freeplane_plugin_grpc/grpc/python
 # if you have installed and configured awscli https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
 $ aws ec2 list-instances | python3 ./freeplane_ec2.py
 # if you don't have amazon cli tool, you can use just the example data from this repo
-$ cat ec2_list_instances.json | python3 ./freeplane_ec2.py 
+$ cat ec2_list_instances.json | python3 ./freeplane_ec2.py
 ```
 
 ![python_example](https://user-images.githubusercontent.com/5146707/215350404-bef09103-90c8-4b91-9fb4-da76fb4fe24f.gif)
@@ -127,17 +128,17 @@ $ cat ec2_list_instances.json | python3 ./freeplane_ec2.py
 
 
 **<a id="example_shell">3.3 Shell example</a>**
-   
-   This example demonstrates how you can interact with a running Freeplane instance from a terminal bash session using the [grpcurl]( https://github.com/fullstorydev/grpcurl) CLI tool 
+
+   This example demonstrates how you can interact with a running Freeplane instance from a terminal bash session using the [grpcurl]( https://github.com/fullstorydev/grpcurl) CLI tool
    The shell example will retrieve the current temperature using the sensors utility, parse the output, and update the mind map every 0.1 seconds in infinite loop.
 
 ```bash
-# install grpcurl in any convient way https://github.com/fullstorydev/grpcurl/releases 
+# install grpcurl in any convient way https://github.com/fullstorydev/grpcurl/releases
 # https://repology.org/project/grpcurl/information
 # I preffer to use grpcurl inside docker container
-# also, you need to edit grpcurl_test.sh 
-$ alias grpcurl="docker run -i -v `pwd`:/host/ -w /host --network=host fullstorydev/grpcurl" 
-$ git clone https://github.com/metacoma/freeplane_plugin_grpc 
+# also, you need to edit grpcurl_test.sh
+$ alias grpcurl="docker run -i -v `pwd`:/host/ -w /host --network=host fullstorydev/grpcurl"
+$ git clone https://github.com/metacoma/freeplane_plugin_grpc
 $ cd freeplane_plugin_grpc/grpc/shell
 # install lm_sensors package to grab gather the temperature sensor
 $ bash ./grpcurl_test.sh
@@ -150,8 +151,8 @@ $ bash ./grpcurl_test.sh
 
   The Freeplane plugin gRPC starts by launching the Freeplane instance and listens on TCP4 port 50051 to accept gRPC clients.
 
-  Once a gRPC client connects and calls a gRPC function, the plugin will use the Freeplane Java API to create, delete, or modify the mind map. 
-  Then returns the result to the gRPC client, such as the ID of a new node or the result code of the operation. 
+  Once a gRPC client connects and calls a gRPC function, the plugin will use the Freeplane Java API to create, delete, or modify the mind map.
+  Then returns the result to the gRPC client, such as the ID of a new node or the result code of the operation.
 
   The diagram below illustrates the high-level architecture.
 
@@ -165,7 +166,7 @@ service Freeplane {
   rpc NodeAttributeAdd (NodeAttributeAddRequest) returns (NodeAttributeAddResponse) {};
   rpc NodeLinkSet (NodeLinkSetRequest) returns (NodeLinkSetResponse) {};
   rpc NodeDetailsSet (NodeDetailsSetRequest) returns (NodeDetailsSetResponse) {};
-  rpc Groovy (GroovyRequest) returns (GroovyResponse) {}; // not ready 
+  rpc Groovy (GroovyRequest) returns (GroovyResponse) {}; // not ready
   rpc NodeColorSet (NodeColorSetRequest) returns (NodeColorSetResponse) {};
   rpc NodeBackgroundColorSet (NodeBackgroundColorSetRequest) returns (NodeBackgroundColorSetResponse) {};
 }
@@ -174,16 +175,16 @@ service Freeplane {
   As you can see, this plugin enables remote control of mind maps over the network, allowing you to send data to multiple Freeplane instances on different computers.
 
   ![image](https://github.com/metacoma/freeplane_plugin_grpc/blob/main/misc/freeplane_multinode.png?raw=true)
-  
+
   And here is rough plan how i will use Freeplane and freeplane_plugin_grpc in [MindWM](https://github.com/metacoma/mindwm)
 
 
   ![image](https://github.com/metacoma/freeplane_plugin_grpc/blob/main/misc/freeplane_network.png?raw=true)
- 
+
 **<a id="quick_start">5. Quick start</a>**
 
 **<a id="install_plugin>">5.1 Install plugin</a>**
- 
+
   Install pre-built plugin from [Release](https://github.com/metacoma/freeplane_plugin_grpc/releases) GitHub page.
 
 **<a id="build_plugin">5.2 Build plugin</a>**
@@ -217,10 +218,10 @@ Freeplane grpc plugin loaded and listen 50051 port
 ```
 
 **<a id="add_new_grpc_function">5.3. Add new gRPC function</a>**
- 
- Let's add a new gRPC function, "StatusInfoSet," similar to "c.StatusInfo = '...'", in Groovy. 
 
- The freeplane.Freeplane.StatusInfoSet gRPC function will accept a single argument, statusInfo, as a string and return a boolean status code. 
+ Let's add a new gRPC function, "StatusInfoSet," similar to "c.StatusInfo = '...'", in Groovy.
+
+ The freeplane.Freeplane.StatusInfoSet gRPC function will accept a single argument, statusInfo, as a string and return a boolean status code.
 
  If successful, the status code will be true; if failed, the status code will be false.
 
@@ -246,7 +247,7 @@ message StatusInfoSetResponse {
 2. Next, let's implement gRPC function handler for StatusInfoSet function
 
 ```java
-//Add this import in the import section in the head of the 
+//Add this import in the import section in the head of the
 import org.freeplane.features.ui.ViewController;
 //.......
 // Add statusInfoSet public java method inside class FreeplaneImpl definition
@@ -270,21 +271,21 @@ import org.freeplane.features.ui.ViewController;
 //....
 ```
 
-3. That's it! Let's try to call our new gRPC function 
+3. That's it! Let's try to call our new gRPC function
 
 Shell example with using grpcurl cli tool
-```bash 
-# note, you need specify the path for freeplane.proto, because the current implementation of gRPC doesn't support reflective api 
+```bash
+# note, you need specify the path for freeplane.proto, because the current implementation of gRPC doesn't support reflective api
 $ echo '{"statusInfo": "hello from shell"}' | grpcurl -plaintext -proto ./freeplane.proto -d @ 127.0.0.1:50051 freeplane.Freeplane/StatusInfoSet
 {
   "success": true
 }
 ```
- 
+
   For python and ruby, you need do "regenerate" freeplane grpc libraries:
 
   For more details, please check [python](https://grpc.io/docs/languages/python/basics/) and [ruby](https://grpc.io/docs/languages/ruby/basics/) basic gRPC tutorial.
-  
+
 ```bash
 $ cd freeplane/freeplane_plugin_grpc
 # for python

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     lib "io.grpc:grpc-protobuf:${grpcVersion}"
     lib "io.grpc:grpc-stub:${grpcVersion}"
     lib "io.grpc:grpc-netty-shaded:${grpcVersion}"
+    lib "io.grpc:grpc-netty:${grpcVersion}"
     lib "com.google.protobuf:protobuf-java-util:${protobufVersion}"
     lib 'org.json:json:20210307'
 


### PR DESCRIPTION
```bash
$ export GRPC_LISTEN_ADDR=127.0.0.1
$ export GRPC_LISTEN_PORT=50052
$ BIN/freeplane.sh
...
Freeplane grpc plugin loaded and listen on 127.0.0.1:50052
...
```