### PR TITLE
ci: add integration and smoke tests against real Freeplane instance

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,186 @@
+name: Integration Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *"
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    concurrency: integration-${{ github.ref }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "8"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+          working-directory: grpc/ruby
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('**/build.gradle') }}
+          restore-keys: |
+            gradle-
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y xvfb xauth openbox procps netcat-openbsd
+
+      - name: Clone Freeplane source
+        run: |
+          git clone --depth 1 --branch release-1.12.18 \
+            https://github.com/freeplane/freeplane.git /workspace/freeplane
+
+      - name: Integrate plugin into Freeplane
+        run: |
+          PLUGIN_DIR="/workspace/freeplane/freeplane_plugin_grpc"
+          mkdir -p "$PLUGIN_DIR"
+          tar cf - --exclude='.git' --exclude='__pycache__' --exclude='*.egg-info' \
+            --exclude='*.egg' --exclude='.gradle' --exclude='build' \
+            --exclude='.pytest_cache' --exclude='.venv' --exclude='*.pyc' \
+            --exclude='node_modules' --exclude='Gemfile.lock' --exclude='.bundle' \
+            --exclude='vendor' . | (cd "$PLUGIN_DIR" && tar xf -)
+          echo "include 'freeplane_plugin_grpc'" >> /workspace/freeplane/settings.gradle
+
+      - name: Build Freeplane
+        working-directory: /workspace/freeplane
+        run: |
+          ./gradlew dist -x test -x check_translation --no-daemon
+          echo "--- Verifying build artifacts ---"
+          test -f BIN/freeplane.sh && echo "freeplane.sh: OK" || { echo "freeplane.sh: MISSING"; exit 1; }
+          test -d BIN/plugins/org.freeplane.plugin.grpc && echo "grpc plugin: OK" || { echo "grpc plugin: MISSING"; exit 1; }
+
+      - name: Start Xvfb and window manager
+        run: |
+          source misc/scripts/start-xvfb-freeplane-env.sh
+          echo "DISPLAY_NUM=$DISPLAY_NUM" >> "$GITHUB_ENV"
+
+      - name: Start Freeplane
+        run: |
+          export DISPLAY=":$DISPLAY_NUM"
+          export _JAVA_AWT_WM_NONREPARENTING=1
+          mkdir -p /tmp/freeplane-xvfb
+          MINDMAP_FILE="/tmp/freeplane-xvfb/smoke_test_map.mm"
+          if [ -f grpc/python/examples/test_blank_map.mm ]; then
+            cp grpc/python/examples/test_blank_map.mm "$MINDMAP_FILE"
+          else
+            cat > "$MINDMAP_FILE" <<'MMEOF'
+          <map version="freeplane 1.9.0">
+          <node TEXT="Smoke Test Map" FOLDED="false" ID="ID_00000001" CREATED="0000000000000" MODIFIED="0000000000000">
+          </node>
+          </map>
+          MMEOF
+          fi
+          /workspace/freeplane/BIN/freeplane.sh "$MINDMAP_FILE" > /tmp/freeplane-xvfb/freeplane.log 2>&1 &
+          FREEPLANE_PID=$!
+          echo "$FREEPLANE_PID" > /tmp/freeplane-xvfb/freeplane.pid
+          echo "FREEPLANE_PID=$FREEPLANE_PID" >> "$GITHUB_ENV"
+          echo "Freeplane started (PID $FREEPLANE_PID)"
+
+      - name: Wait for gRPC server readiness
+        run: |
+          GRPC_HOST="127.0.0.1"
+          GRPC_PORT="50051"
+
+          echo "=== TCP readiness check (up to 120s) ==="
+          GRPC_READY=false
+          for i in $(seq 1 60); do
+            if nc -z "$GRPC_HOST" "$GRPC_PORT" 2>/dev/null; then
+              GRPC_READY=true
+              echo "gRPC TCP port ready after $((i * 2)) seconds"
+              break
+            fi
+            sleep 2
+          done
+          if [ "$GRPC_READY" != "true" ]; then
+            echo "ERROR: gRPC TCP port did not become ready within 120 seconds"
+            echo "--- Freeplane log (last 50 lines) ---"
+            tail -50 /tmp/freeplane-xvfb/freeplane.log || true
+            exit 1
+          fi
+
+          echo "=== gRPC-level readiness check (up to 120s) ==="
+          pip install --quiet grpcio protobuf
+          MAP_READY=false
+          for i in $(seq 1 60); do
+            RESULT=$(GRPC_HOST="$GRPC_HOST" GRPC_PORT="$GRPC_PORT" GRPC_TIMEOUT="3" \
+              python3 misc/scripts/_check_grpc_map.py 2>/dev/null || true)
+            if [ "$RESULT" = "OK" ]; then
+              MAP_READY=true
+              echo "MindMap mode activated after $((i * 2)) seconds"
+              break
+            fi
+            sleep 2
+          done
+          if [ "$MAP_READY" != "true" ]; then
+            echo "ERROR: gRPC server ready but no map available after 120 seconds"
+            echo "--- Freeplane log (last 30 lines) ---"
+            tail -30 /tmp/freeplane-xvfb/freeplane.log || true
+            exit 1
+          fi
+
+      - name: Run Ruby integration tests
+        run: |
+          cd grpc/ruby
+          FREEPLANE_HOST=127.0.0.1 FREEPLANE_PORT=50051 bundle exec rspec spec/integration/
+
+      - name: Run Python smoke tests
+        run: |
+          pip install --quiet grpcio protobuf
+          python3 grpc/python/examples/modify_mindmap_example.py
+          python3 grpc/python/examples/test_json_roundtrip.py
+
+      - name: Upload Freeplane log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: freeplane-log
+          path: /tmp/freeplane-xvfb/freeplane.log
+          if-no-files-found: ignore
+
+      - name: Cleanup Freeplane and Xvfb
+        if: always()
+        run: |
+          # Stop Freeplane
+          if [ -f /tmp/freeplane-xvfb/freeplane.pid ]; then
+            FP_PID=$(cat /tmp/freeplane-xvfb/freeplane.pid)
+            if kill -0 "$FP_PID" 2>/dev/null; then
+              echo "Stopping Freeplane (PID $FP_PID)..."
+              kill "$FP_PID" 2>/dev/null || true
+              waited=0
+              while [ $waited -lt 15 ]; do
+                kill -0 "$FP_PID" 2>/dev/null || break
+                sleep 1
+                waited=$((waited + 1))
+              done
+              if kill -0 "$FP_PID" 2>/dev/null; then
+                echo "Freeplane did not exit gracefully — sending SIGKILL"
+                kill -9 "$FP_PID" 2>/dev/null || true
+              fi
+            fi
+          fi
+
+          # Stop Xvfb and window manager
+          bash misc/scripts/stop-xvfb-freeplane-env.sh || true

--- a/misc/scripts/run-freeplane-python-smoke-test.sh
+++ b/misc/scripts/run-freeplane-python-smoke-test.sh
@@ -17,8 +17,8 @@
 
 set -euo pipefail
 
-PLUGIN_REPO="/workspace/freeplane_plugin_grpc"
-FREEPLANE_SRC="/workspace/freeplane"
+PLUGIN_REPO="${PLUGIN_REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+FREEPLANE_SRC="${FREEPLANE_SRC:-/workspace/freeplane}"
 RUNTIME_DIR="/tmp/freeplane-xvfb"
 GRPC_HOST="127.0.0.1"
 GRPC_PORT="50051"


### PR DESCRIPTION
## Summary

Adds integration tests and smoke tests to the GitHub Actions pipeline, running against a **real Freeplane instance** (not mocks).

## Changes

### New: `.github/workflows/integration.yml`
- 16-step workflow that:
  1. Checks out code, sets up Java 8, Python 3.10, Ruby 3.2
  2. Caches Gradle build outputs
  3. Clones Freeplane source at `release-1.12.18`
  4. Integrates the gRPC plugin and builds Freeplane
  5. Starts Xvfb + window manager
  6. Starts Freeplane with a test mindmap
  7. Waits for gRPC server readiness (TCP + gRPC-level check)
  8. Runs **37 Ruby integration tests** (`spec/integration/`)
  9. Runs **Python smoke tests** (`modify_mindmap_example.py`, `test_json_roundtrip.py`)
  10. Uploads Freeplane log as artifact on failure
  11. Cleans up Freeplane/Xvfb processes (always)
- Triggers: `workflow_dispatch` (manual) + nightly schedule (06:00 UTC)
- Timeout: 45 minutes, concurrency control per ref

### Modified: `misc/scripts/run-freeplane-python-smoke-test.sh`
- Parameterized `PLUGIN_REPO` and `FREEPLANE_SRC` (was hardcoded to `/workspace/...`)
- Now matches the Ruby smoke test script conventions

## What is NOT changed
- `.github/workflows/ci.yml` — existing unit test CI remains unchanged
- Ruby integration test files — already written and gated by `FREEPLANE_HOST`
- Python smoke test examples — already written

## Validation
- YAML syntax validated
- Freeplane tag `release-1.12.18` verified via GitHub API
- All referenced files and scripts exist in the repository
- Existing CI workflow untouched

## Risks
- Freeplane build may take 15-30 minutes (mitigated by Gradle caching)
- Xvfb reliability in CI (mitigated by openbox WM + proven scripts)
- Some Ruby integration tests may be non-deterministic (documented in test code)

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._
