### PR TITLE
fix(ci): use GitHub Actions expression syntax for working-directory in integration.yml

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -73,7 +73,7 @@ jobs:
           echo "include 'freeplane_plugin_grpc'" >> "$FREEPLANE_SRC/settings.gradle"
 
       - name: Build Freeplane
-        working-directory: $FREEPLANE_SRC
+        working-directory: ${{ env.FREEPLANE_SRC }}
         run: |
           ./gradlew dist -x test -x check_translation --no-daemon
           echo "--- Verifying build artifacts ---"


### PR DESCRIPTION
## Summary

Fixes the GitHub Actions CI failure in `.github/workflows/integration.yml` where the "Build Freeplane" step fails because `working-directory` uses shell variable syntax (`$FREEPLANE_SRC`) instead of the GitHub Actions expression syntax (`${{ env.FREEPLANE_SRC }}`).

## Root Cause

GitHub Actions YAML fields like `working-directory` do **not** support shell `$VAR` expansion. They require `${{ }}` expression syntax. The literal string `$FREEPLANE_SRC` was being used as the working directory path, causing Gradle to fail with a "directory not found" error.

## Changes

| File | Line | Change |
|------|------|--------|
| `.github/workflows/integration.yml` | 76 | `working-directory: $FREEPLANE_SRC` → `working-directory: ${{ env.FREEPLANE_SRC }}` |

## Validation

- **YAML syntax:** Validated with pyyaml — passed.
- **Diff review:** Exactly 1 file, 1 line changed. All other `$FREEPLANE_SRC` references are inside `run:` blocks where shell expansion is correct.
- **Reviewer decision:** PASS — one-line fix verified, no issues found.

## Risks

- **Low risk:** Single-line syntax fix. No logic changes.
- The fix should be empirically validated by triggering a `workflow_dispatch` run on this branch.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._