### PR TITLE
fix(ci): use system gradle and Java 17 for Freeplane build

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,11 +15,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Java 8
+      - name: Set up Java 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "8"
+          java-version: "17"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -75,7 +75,7 @@ jobs:
       - name: Build Freeplane
         working-directory: ${{ env.FREEPLANE_SRC }}
         run: |
-          ./gradlew dist -x test -x check_translation --no-daemon
+          gradle dist -x test -x check_translation --no-daemon
           echo "--- Verifying build artifacts ---"
           test -f BIN/freeplane.sh && echo "freeplane.sh: OK" || { echo "freeplane.sh: MISSING"; exit 1; }
           test -d BIN/plugins/org.freeplane.plugin.grpc && echo "grpc plugin: OK" || { echo "grpc plugin: MISSING"; exit 1; }


### PR DESCRIPTION
## Summary

Fix the "Build Freeplane" CI step that fails with exit code 127 (command not found).

**Root cause:** The workflow ran `./gradlew dist` but Freeplane has no Gradle wrapper. Additionally, Gradle 9.5.1 on ubuntu-latest requires Java 17+ but the workflow set up Java 8.

## Changes (3 lines in 1 file)

- `.github/workflows/integration.yml`: Java 8 -> Java 17
- `.github/workflows/integration.yml`: `./gradlew dist` -> `gradle dist`

## Why This Works

- Freeplane has no Gradle wrapper; uses system `gradle`
- Gradle 9.5.1 requires Java 17+ to execute
- Freeplane compiles to Java 8 bytecode and runs on Java 17
- Freeplane's own CI uses Java 17/21

## Validation

- Reviewer: PASS
- Fixes CI run #27566476910 (exit code 127)

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._