### PR TITLE
Fix: rootNode not effectively final in lambda

### DIFF
--- a/src/main/java/org/freeplane/plugin/grpc/FreeplaneGrpcService.java
+++ b/src/main/java/org/freeplane/plugin/grpc/FreeplaneGrpcService.java
@@ -829,13 +829,14 @@ class FreeplaneGrpcService extends FreeplaneGrpc.FreeplaneImplBase {
 
         // Use LinkedHashMap for deterministic field ordering in canonical JSON
         final Map<String, Object> result = new java.util.LinkedHashMap<>();
+        final NodeModel finalRootNode = rootNode;
         try {
             if (EventQueue.isDispatchThread()) {
-                jsonHelper.nodeWalk(result, rootNode);
+                jsonHelper.nodeWalk(result, finalRootNode);
             } else {
                 SwingUtilities.invokeAndWait(() -> {
                     try {
-                        jsonHelper.nodeWalk(result, rootNode);
+                        jsonHelper.nodeWalk(result, finalRootNode);
                     } catch (final Exception e) {
                         throw new RuntimeException(e);
                     }


### PR DESCRIPTION
Fixes compilation error in CI run #27580898344. Adds final wrapper for rootNode to allow lambda capture in SwingUtilities.invokeAndWait.

## Changes
- Added `final NodeModel finalRootNode = rootNode;` before the try block (line 832)
- Replaced both `rootNode` references with `finalRootNode` in `jsonHelper.nodeWalk()` calls (lines 835, 839)
- Single-file, three-line change with no behavioral impact

## QA Validation
- **Status**: PASS
- Compiled successfully with `gradle :freeplane_plugin_grpc:compileJava --no-daemon` (BUILD SUCCESSFUL, 0 errors, 14 tasks)
- Environment: Java 21, Gradle 9.5.1 (CI uses Java 17 — no risk for this syntax-level fix)

## Reviewer Decision
- **Status**: PASS (risk_level: low, blocking: False)
- Confirmed correctness: `finalRootNode` satisfies JLS lambda capture requirement
- Assigned after null-check guard, both usage sites consistent
- No unrelated modifications

## Risks
- Minimal: compile-only fix, no runtime behavior change
- No runtime tests performed (compile-only fix)

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._