### PR TITLE
feat: support absolute paths in openMap and add OpenMap smoke test steps

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -163,10 +163,34 @@ jobs:
             exit 1
           fi
 
+      - name: Open blank map via gRPC
+        run: |
+          python3 -c "
+          import sys; sys.path.insert(0, 'grpc/python')
+          from freeplane_pb2 import OpenMapRequest
+          import freeplane_pb2_grpc, grpc
+          stub = freeplane_pb2_grpc.FreeplaneStub(grpc.insecure_channel('127.0.0.1:50051'))
+          resp = stub.OpenMap(OpenMapRequest(file_path='/tmp/freeplane-xvfb/smoke_test_map.mm'))
+          assert resp.success, 'OpenMap failed'
+          print('OpenMap OK')
+          "
+
       - name: Run Ruby integration tests
         run: |
           cd grpc/ruby
           FREEPLANE_HOST=127.0.0.1 FREEPLANE_PORT=50051 bundle exec rspec spec/integration/
+
+      - name: Re-open blank map for Python tests
+        run: |
+          python3 -c "
+          import sys; sys.path.insert(0, 'grpc/python')
+          from freeplane_pb2 import OpenMapRequest
+          import freeplane_pb2_grpc, grpc
+          stub = freeplane_pb2_grpc.FreeplaneStub(grpc.insecure_channel('127.0.0.1:50051'))
+          resp = stub.OpenMap(OpenMapRequest(file_path='/tmp/freeplane-xvfb/smoke_test_map.mm'))
+          assert resp.success, 'OpenMap failed'
+          print('OpenMap OK')
+          "
 
       - name: Run Python smoke tests
         run: |

--- a/misc/scripts/run-freeplane-python-smoke-test.sh
+++ b/misc/scripts/run-freeplane-python-smoke-test.sh
@@ -279,6 +279,28 @@ if ! $MAP_READY; then
     exit 1
 fi
 
+# --- Step 4b: Open blank map via gRPC to override demo map ---
+echo ""
+echo "=========================================="
+echo " Step 4b: Open blank map via gRPC"
+echo "=========================================="
+log_info "Opening blank map via gRPC to override Freeplane demo map..."
+OPEN_MAP_RESULT=$(python3 -c "
+import sys, os
+sys.path.insert(0, os.path.join('${PLUGIN_REPO}', 'grpc/python'))
+from freeplane_pb2 import OpenMapRequest
+import freeplane_pb2_grpc, grpc
+stub = freeplane_pb2_grpc.FreeplaneStub(grpc.insecure_channel('${GRPC_HOST}:${GRPC_PORT}'))
+resp = stub.OpenMap(OpenMapRequest(file_path='${MINDMAP_FILE}'))
+print('success' if resp.success else 'failed')
+" 2>&1)
+if [[ "$OPEN_MAP_RESULT" == *"success"* ]]; then
+    log_info "Blank map opened successfully via gRPC"
+else
+    log_warn "OpenMap call returned: $OPEN_MAP_RESULT"
+    log_warn "Tests may run on the demo map instead of the blank map"
+fi
+
 # --- Step 5: Run Python example ---
 echo ""
 echo "=========================================="

--- a/misc/scripts/run-freeplane-ruby-smoke-test.sh
+++ b/misc/scripts/run-freeplane-ruby-smoke-test.sh
@@ -258,6 +258,28 @@ if ! $MAP_READY; then
     exit 1
 fi
 
+# --- Step 4b: Open blank map via gRPC to override demo map ---
+echo ""
+echo "=========================================="
+echo " Step 4b: Open blank map via gRPC"
+echo "=========================================="
+log_info "Opening blank map via gRPC to override Freeplane demo map..."
+OPEN_MAP_RESULT=$(python3 -c "
+import sys, os
+sys.path.insert(0, os.path.join('${PLUGIN_REPO}', 'grpc/python'))
+from freeplane_pb2 import OpenMapRequest
+import freeplane_pb2_grpc, grpc
+stub = freeplane_pb2_grpc.FreeplaneStub(grpc.insecure_channel('${GRPC_HOST}:${GRPC_PORT}'))
+resp = stub.OpenMap(OpenMapRequest(file_path='${MINDMAP_FILE}'))
+print('success' if resp.success else 'failed')
+" 2>&1)
+if [[ "$OPEN_MAP_RESULT" == *"success"* ]]; then
+    log_info "Blank map opened successfully via gRPC"
+else
+    log_warn "OpenMap call returned: $OPEN_MAP_RESULT"
+    log_warn "Tests may run on the demo map instead of the blank map"
+fi
+
 # --- Step 5: Install Ruby dependencies ---
 echo ""
 echo "=========================================="

--- a/src/main/java/org/freeplane/plugin/grpc/FreeplaneGrpcService.java
+++ b/src/main/java/org/freeplane/plugin/grpc/FreeplaneGrpcService.java
@@ -606,7 +606,13 @@ class FreeplaneGrpcService extends FreeplaneGrpc.FreeplaneImplBase {
         LOG.info("GRPC Freeplane::openMap(mapFilePath: " + mapFilePath + ")");
 
         if (mapFilePath != null) {
-            String path = System.getProperty("user.home") + "/mindmaps/" + mapFilePath;
+            final File requestedFile = new File(mapFilePath);
+            String path;
+            if (requestedFile.isAbsolute()) {
+                path = mapFilePath;
+            } else {
+                path = System.getProperty("user.home") + "/mindmaps/" + mapFilePath;
+            }
             final File file = new File(path);
 
             try {


### PR DESCRIPTION
## Changes

### Java
- **FreeplaneGrpcService**: `openMap()` now checks if the provided path is absolute. If so, it uses it directly instead of always prepending `~/mindmaps/`.

### CI / Smoke Tests
- **integration.yml**: Added `OpenMap` gRPC calls before Ruby and Python test steps to ensure a blank map is opened (overrides Freeplane demo map).
- **run-freeplane-python-smoke-test.sh**: Added Step 4b — open blank map via gRPC.
- **run-freeplane-ruby-smoke-test.sh**: Added Step 4b — open blank map via gRPC.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._