### PR TITLE
ci: add Ruby smoke test and enable integration tests on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,10 @@ jobs:
           bundler-cache: true
           working-directory: grpc/ruby
 
+      - name: Ruby smoke test
+        working-directory: grpc/ruby
+        run: |
+          bundle exec ruby -e 'require "freeplane_grpc_client"; puts FreeplaneGrpcClient::VERSION'
+
       - name: Run tests
         run: bash scripts/run-tests.sh

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 6 * * *"
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   integration:


### PR DESCRIPTION
## Changes

### ci.yml: Ruby smoke test
- Added a lightweight **Ruby smoke test** step that validates the `freeplane_grpc_client` gem loads successfully and prints its VERSION (`0.1.0`).
- Runs after Ruby setup (`ruby/setup-ruby@v1` with `bundler-cache: true`) and before the existing test runner.
- No Freeplane server required; completes in under 5 seconds.

### integration.yml: Integration tests on every PR
- Added `pull_request` trigger with types `[opened, synchronize, reopened]` so integration tests run on every PR.
- Existing `workflow_dispatch` and `schedule` triggers preserved.
- Existing concurrency control (`integration-${{ github.ref }}`) prevents duplicate runs.

## Validation

- **QA**: Ruby smoke test runtime-validated (`bundle exec ruby -e` outputs `0.1.0`, exit 0). Ruby unit tests (92 examples) and Python unit tests (70 tests) all pass. YAML syntax valid.
- **Reviewer**: Both workflow changes independently validated. No existing steps modified. No security concerns.

## Risks

- Integration tests add ~45 min to every PR (user explicitly requested this behavior).
- Concurrency control prevents duplicate runs on the same branch.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._