### PR TITLE
feat: add Node.js gRPC client for Freeplane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,14 @@ jobs:
         run: |
           bundle exec ruby -e 'require "freeplane_grpc_client"; puts FreeplaneGrpcClient::VERSION'
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Node.js dependencies
+        working-directory: grpc/nodejs
+        run: npm ci
+
       - name: Run tests
         run: bash scripts/run-tests.sh

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,6 +35,11 @@ jobs:
           bundler-cache: true
           working-directory: grpc/ruby
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
       - name: Cache Gradle
         uses: actions/cache@v4
         with:
@@ -181,6 +186,27 @@ jobs:
         run: |
           cd grpc/ruby
           FREEPLANE_HOST=127.0.0.1 FREEPLANE_PORT=50051 bundle exec rspec spec/integration/
+
+      - name: Install Node.js dependencies
+        working-directory: grpc/nodejs
+        run: npm ci
+
+      - name: Re-open blank map for Node.js tests
+        run: |
+          python3 -c "
+          import sys; sys.path.insert(0, 'grpc/python')
+          from freeplane_pb2 import OpenMapRequest
+          import freeplane_pb2_grpc, grpc
+          stub = freeplane_pb2_grpc.FreeplaneStub(grpc.insecure_channel('127.0.0.1:50051'))
+          resp = stub.OpenMap(OpenMapRequest(file_path='/tmp/freeplane-xvfb/smoke_test_map.mm'), timeout=10)
+          assert resp.success, 'OpenMap failed'
+          print('OpenMap OK')
+          "
+
+      - name: Run Node.js integration tests
+        run: |
+          cd grpc/nodejs
+          FREEPLANE_HOST=127.0.0.1 FREEPLANE_PORT=50051 npx jest --testPathPattern=test/integration --verbose --runInBand
 
       - name: Re-open blank map for Python tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ build/
 *.swp
 *.swo
 
+# Node.js
+node_modules/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/grpc/nodejs/README.md
+++ b/grpc/nodejs/README.md
@@ -1,0 +1,115 @@
+# freeplane-grpc-client (Node.js)
+
+Node.js gRPC client for the [Freeplane](https://www.freeplane.org/) mind-map application.
+
+## Requirements
+
+- Node.js >= 18.0.0 (LTS)
+- Freeplane with the gRPC plugin enabled (default port: 50051)
+
+## Installation
+
+```bash
+cd grpc/nodejs
+npm install
+```
+
+## Usage
+
+```javascript
+const { FreeplaneClient } = require('./src/index');
+
+async function main() {
+  const client = new FreeplaneClient();
+  await client.connect();
+
+  try {
+    const map = await client.currentMap();
+    const root = await map.root();
+    console.log('Root:', await root.getText());
+
+    const child = await root.addChild('Hello from Node.js');
+    await child.setText('Modified text');
+    await child.setNote('A note');
+    await child.setTags(['tag1', 'tag2']);
+
+    const json = await client.getMapToJson();
+    console.log('Map JSON length:', json.length);
+
+    await child.delete();
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch(console.error);
+```
+
+## Configuration
+
+| Environment Variable | Constructor Option | Default     | Description              |
+|---------------------|-------------------|-------------|--------------------------|
+| `FREEPLANE_HOST`    | `options.host`    | `127.0.0.1` | Freeplane gRPC server host |
+| `FREEPLANE_PORT`    | `options.port`    | `50051`     | Freeplane gRPC server port |
+
+Constructor options take precedence over environment variables.
+
+## API
+
+### FreeplaneClient
+
+- `connect()` — Open gRPC channel
+- `close()` — Close gRPC channel
+- `currentMap()` — Get the current mind map
+- `openMap(filePath)` — Open a .mm file
+- `getMapToJson()` — Export current map as JSON
+- `mindMapFromJson(json)` — Import map from JSON
+- `groovy(code)` — Execute Groovy code on the server
+- `focusNode(nodeId)` — Focus a node in the UI
+- `setStatusInfo(info)` — Set status bar text
+
+### Node
+
+- `getText()` / `setText(text)`
+- `addChild(text)` / `children()` / `parent()` / `delete()` / `move(newParentId)`
+- `getNote()` / `setNote(note)`
+- `getAttribute(name)` / `setAttribute(name, value)` / `setAttributes(attrs)`
+- `getLinks()` / `setLinks(links)`
+- `setTags(tags)` / `addTags(tags)`
+- `addIcon(iconName)`
+- `setColor(r, g, b, a)` / `setBackgroundColor(r, g, b, a)`
+- `select()` / `center()` / `refresh()`
+
+### MindMap
+
+- `root()` — Get the root node
+- `selectedNode()` — Get the currently selected node
+- `findNodes(pattern)` — Search nodes by text
+- `createNode(text, parentId)` / `createChild(parent, text)`
+- `info()` / `size()`
+- `save(path)` / `export(path, format)` / `importMap(path)`
+
+### Exceptions
+
+- `FreeplaneGrpcError` — Base exception
+- `FreeplaneConnectionError` — Connection/network failures
+- `FreeplaneOperationError` — Server-reported operation failures
+- `NodeNotFoundError` — Requested node does not exist
+- `MindMapError` — Map-level operation failures
+
+## Testing
+
+```bash
+# Unit tests (mocked, no server required)
+npm test
+
+# Integration tests (requires FREEPLANE_HOST)
+FREEPLANE_HOST=127.0.0.1 npm run test:integration
+
+# All tests
+npm run test:all
+```
+
+## Examples
+
+See `examples/basic_usage.js` and `examples/smoke_test.js`.

--- a/grpc/nodejs/examples/basic_usage.js
+++ b/grpc/nodejs/examples/basic_usage.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Basic usage example for the freeplane-grpc-client.
+ *
+ * Demonstrates connecting to Freeplane, navigating the mind map,
+ * creating nodes, and modifying content.
+ *
+ * Requires a running Freeplane instance with the gRPC plugin enabled.
+ *
+ * Usage:
+ *   node examples/basic_usage.js
+ *   FREEPLANE_HOST=10.0.0.1 FREEPLANE_PORT=50051 node examples/basic_usage.js
+ */
+
+const { FreeplaneClient } = require('../src/index');
+
+async function main() {
+  const client = new FreeplaneClient();
+
+  try {
+    console.log(`Connecting to Freeplane at ${client.host}:${client.port}...`);
+    await client.connect();
+    console.log('Connected!');
+
+    // Get the current mind map
+    const map = await client.currentMap();
+    console.log(`Current map: ${map.toString()}`);
+
+    // Get the root node
+    const root = await map.root();
+    console.log(`Root node: ${root.nodeId} - "${await root.getText()}"`);
+
+    // List root children
+    const children = await root.children();
+    console.log(`Root has ${children.length} children`);
+
+    // Create a new child node
+    const timestamp = new Date().toISOString();
+    const child = await root.addChild(`Node.js Test ${timestamp}`);
+    console.log(`Created child: ${child.nodeId}`);
+
+    // Modify the child node
+    await child.setText('Modified by Node.js client');
+    await child.setNote('This note was added by the Node.js gRPC client');
+    await child.setTags(['test', 'nodejs']);
+    await child.setColor(255, 0, 0, 255);
+
+    // Verify changes
+    const text = await child.getText();
+    console.log(`Child text: "${text}"`);
+
+    // Export map to JSON
+    const json = await client.getMapToJson();
+    console.log(`Map JSON length: ${json.length} characters`);
+
+    // Set status info
+    await client.setStatusInfo('Node.js client connected and working!');
+
+    // Cleanup: delete the test node
+    await child.delete();
+    console.log('Test node deleted');
+
+    console.log('\nBasic usage example completed successfully!');
+  } catch (err) {
+    console.error('Error:', err.message);
+    process.exitCode = 1;
+  } finally {
+    await client.close();
+    console.log('Connection closed');
+  }
+}
+
+main();

--- a/grpc/nodejs/examples/smoke_test.js
+++ b/grpc/nodejs/examples/smoke_test.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Smoke test for the freeplane-grpc-client.
+ *
+ * Performs a minimal end-to-end test:
+ *   1. Connect to Freeplane
+ *   2. Get current map
+ *   3. Create a node
+ *   4. Read back the node text
+ *   5. Export JSON and verify
+ *   6. Delete the test node
+ *
+ * Exit code 0 = pass, 1 = fail.
+ *
+ * Usage:
+ *   node examples/smoke_test.js
+ */
+
+const { FreeplaneClient, FreeplaneConnectionError } = require('../src/index');
+
+async function main() {
+  const client = new FreeplaneClient();
+  let childNode = null;
+
+  try {
+    console.log('[1/6] Connecting to Freeplane...');
+    await client.connect();
+    console.log('  OK: Connected');
+
+    console.log('[2/6] Getting current map...');
+    const map = await client.currentMap();
+    console.log(`  OK: Map ${map.mapId}`);
+
+    console.log('[3/6] Creating test node...');
+    const root = await map.root();
+    const smokeName = `SmokeTest_${Date.now()}`;
+    childNode = await root.addChild(smokeName);
+    console.log(`  OK: Created node ${childNode.nodeId}`);
+
+    console.log('[4/6] Reading back node text...');
+    const text = await childNode.getText();
+    if (text !== smokeName) {
+      throw new Error(`Text mismatch: expected "${smokeName}", got "${text}"`);
+    }
+    console.log(`  OK: Text matches "${text}"`);
+
+    console.log('[5/6] Exporting JSON...');
+    const json = await client.getMapToJson();
+    const parsed = JSON.parse(json);
+    if (!parsed) {
+      throw new Error('JSON export returned empty/invalid data');
+    }
+    console.log(`  OK: JSON exported (${json.length} chars)`);
+
+    console.log('[6/6] Cleaning up...');
+    if (childNode) {
+      await childNode.delete();
+    }
+    console.log('  OK: Test node deleted');
+
+    console.log('\nSMOKE TEST: PASSED');
+    process.exitCode = 0;
+  } catch (err) {
+    console.error(`\nSMOKE TEST: FAILED`);
+    console.error(`  Error: ${err.message}`);
+
+    // Try to cleanup on failure
+    if (childNode) {
+      try {
+        await childNode.delete();
+      } catch (_) {
+        // ignore
+      }
+    }
+    process.exitCode = 1;
+  } finally {
+    try {
+      await client.close();
+    } catch (_) {
+      // ignore
+    }
+  }
+}
+
+main();

--- a/grpc/nodejs/package-lock.json
+++ b/grpc/nodejs/package-lock.json
@@ -1,0 +1,3806 @@
+{
+  "name": "freeplane-grpc-client",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "freeplane-grpc-client",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.10.0",
+        "@grpc/proto-loader": "^0.7.0"
+      },
+      "devDependencies": {
+        "jest": "^29.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.37",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.373",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.373.tgz",
+      "integrity": "sha512-G2Hym8JIf/QreuseqkDibgH8Ci8KfJzqGDKdakbhSx9UltwRBH2cBLAWU/lBX0sCdv0TlhyxQyDCnSfxgMWsjA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/grpc/nodejs/package-lock.json
+++ b/grpc/nodejs/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.10.0",
-        "@grpc/proto-loader": "^0.7.0"
+        "@grpc/proto-loader": "^0.8.0"
       },
       "devDependencies": {
         "jest": "^29.0.0"
@@ -528,7 +528,7 @@
         "node": ">=12.10.0"
       }
     },
-    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+    "node_modules/@grpc/proto-loader": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
       "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
@@ -537,24 +537,6 @@
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
         "protobufjs": "^7.5.5",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@grpc/proto-loader": {
-      "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
-      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash.camelcase": "^4.3.0",
-        "long": "^5.0.0",
-        "protobufjs": "^7.2.5",
         "yargs": "^17.7.2"
       },
       "bin": {

--- a/grpc/nodejs/package.json
+++ b/grpc/nodejs/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "freeplane-grpc-client",
+  "version": "1.0.0",
+  "description": "Node.js gRPC client for Freeplane mind-map application",
+  "main": "src/index.js",
+  "scripts": {
+    "test": "jest --testPathPattern=test/unit --verbose",
+    "test:integration": "jest --testPathPattern=test/integration --verbose --runInBand",
+    "test:all": "jest --verbose"
+  },
+  "keywords": ["freeplane", "grpc", "mindmap"],
+  "author": "metacoma",
+  "license": "MIT",
+  "dependencies": {
+    "@grpc/grpc-js": "^1.10.0",
+    "@grpc/proto-loader": "^0.7.0"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/grpc/nodejs/package.json
+++ b/grpc/nodejs/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "@grpc/grpc-js": "^1.10.0",
-    "@grpc/proto-loader": "^0.7.0"
+    "@grpc/proto-loader": "^0.8.0"
   },
   "devDependencies": {
     "jest": "^29.0.0"

--- a/grpc/nodejs/src/client.js
+++ b/grpc/nodejs/src/client.js
@@ -80,17 +80,14 @@ class FreeplaneClient {
    */
   async connect() {
     try {
-      this._channel = new grpc.Channel(
-        `${this._host}:${this._port}`,
-        grpc.credentials.createInsecure()
-      );
+      const target = `${this._host}:${this._port}`;
+      const credentials = grpc.credentials.createInsecure();
+
+      this._channel = new grpc.Channel(target, credentials, {});
 
       // Load proto and create stub
       const freeplanePkg = loadProto();
-      this._stub = new freeplanePkg.freeplane.Freeplane(
-        this._channel,
-        grpc.credentials.createInsecure()
-      );
+      this._stub = new freeplanePkg.freeplane.Freeplane(target, credentials);
       this._protoLoaded = true;
 
       // Verify connectivity with a timeout

--- a/grpc/nodejs/src/client.js
+++ b/grpc/nodejs/src/client.js
@@ -1,0 +1,402 @@
+/**
+ * FreeplaneClient - the main entry point for interacting with Freeplane via gRPC.
+ *
+ * Uses @grpc/grpc-js with runtime proto-loader for zero-codegen operation.
+ * All public methods are async/await-friendly.
+ */
+
+const grpc = require('@grpc/grpc-js');
+const protoLoader = require('@grpc/proto-loader');
+const path = require('path');
+
+const {
+  FreeplaneConnectionError,
+  FreeplaneOperationError,
+  NodeNotFoundError,
+  MindMapError,
+} = require('./exceptions');
+const MindMap = require('./mindmap');
+
+const DEFAULT_HOST = '127.0.0.1';
+const DEFAULT_PORT = 50051;
+
+/**
+ * Load the proto file and return the package definition.
+ * @returns {object} The loaded proto package definition.
+ */
+function loadProto() {
+  const protoPath = path.join(__dirname, '..', '..', '..', 'src', 'main', 'proto', 'freeplane.proto');
+  const packageDefinition = protoLoader.loadSync(protoPath, {
+    keepCase: true,
+    longs: String,
+    enums: String,
+    defaults: true,
+    oneofs: true,
+  });
+  return grpc.loadPackageDefinition(packageDefinition);
+}
+
+/**
+ * Client for interacting with a Freeplane gRPC server.
+ *
+ * Typical usage:
+ *   const client = new FreeplaneClient();
+ *   await client.connect();
+ *   try {
+ *     const mindmap = await client.currentMap();
+ *     const root = await mindmap.root();
+ *     console.log(await root.getText());
+ *   } finally {
+ *     await client.close();
+ *   }
+ */
+class FreeplaneClient {
+  /**
+   * Create a new FreeplaneClient.
+   * @param {object} [options]
+   * @param {string} [options.host] - Server hostname (default: FREEPLANE_HOST env or 127.0.0.1)
+   * @param {number} [options.port] - Server port (default: FREEPLANE_PORT env or 50051)
+   */
+  constructor(options = {}) {
+    this._host = options.host || process.env.FREEPLANE_HOST || DEFAULT_HOST;
+    this._port = options.port || parseInt(process.env.FREEPLANE_PORT, 10) || DEFAULT_PORT;
+    this._channel = null;
+    this._stub = null;
+    this._protoLoaded = false;
+  }
+
+  get host() {
+    return this._host;
+  }
+
+  get port() {
+    return this._port;
+  }
+
+  /**
+   * Open (or re-open) the gRPC channel to the server.
+   * @returns {Promise<void>}
+   * @throws {FreeplaneConnectionError}
+   */
+  async connect() {
+    try {
+      this._channel = new grpc.Channel(
+        `${this._host}:${this._port}`,
+        grpc.credentials.createInsecure()
+      );
+
+      // Load proto and create stub
+      const freeplanePkg = loadProto();
+      this._stub = new freeplanePkg.freeplane.Freeplane(
+        this._channel,
+        grpc.credentials.createInsecure()
+      );
+      this._protoLoaded = true;
+
+      // Verify connectivity with a timeout
+      await new Promise((resolve, reject) => {
+        const deadline = Date.now() + 5000;
+        const checkConnectivity = () => {
+          const state = this._channel.getConnectivityState();
+          if (state === grpc.connectivityState.READY || state === grpc.connectivityState.IDLE) {
+            resolve();
+          } else if (Date.now() >= deadline) {
+            reject(new Error('timeout'));
+          } else {
+            setTimeout(checkConnectivity, 100);
+          }
+        };
+        this._channel.watchConnectivityState(grpc.connectivityState.IDLE, deadline, (err) => {
+          if (err) {
+            reject(err);
+          } else {
+            checkConnectivity();
+          }
+        });
+      });
+    } catch (err) {
+      if (this._channel) {
+        try { this._channel.close(); } catch (_) { /* ignore */ }
+      }
+      this._channel = null;
+      this._stub = null;
+      throw new FreeplaneConnectionError(
+        `Failed to connect to Freeplane gRPC server at ${this._host}:${this._port}: ${err.message}`
+      );
+    }
+  }
+
+  /**
+   * Close the gRPC channel if it is open.
+   * @returns {Promise<void>}
+   */
+  async close() {
+    if (this._channel) {
+      try {
+        this._channel.close();
+      } catch (_) {
+        // ignore close errors
+      }
+      this._channel = null;
+    }
+    this._stub = null;
+    this._protoLoaded = false;
+  }
+
+  /**
+   * Get the gRPC stub, ensuring the client is connected.
+   * @returns {*} The gRPC stub.
+   * @throws {FreeplaneConnectionError}
+   * @private
+   */
+  _getStub() {
+    if (!this._stub) {
+      throw new FreeplaneConnectionError(
+        'No active connection. Call connect() first.'
+      );
+    }
+    return this._stub;
+  }
+
+  /**
+   * Call a gRPC method and convert failures to domain exceptions.
+   * Wraps the callback-based gRPC API in a Promise.
+   *
+   * @param {Function} method - The gRPC stub method to invoke.
+   * @param {object} request - The request message object.
+   * @param {number} [timeout] - Optional timeout in milliseconds.
+   * @returns {Promise<object>} The response object.
+   * @throws {FreeplaneConnectionError|FreeplaneOperationError}
+   * @private
+   */
+  _call(method, request, timeout) {
+    return new Promise((resolve, reject) => {
+      const options = {};
+      if (timeout) {
+        options.deadline = new Date(Date.now() + timeout);
+      }
+
+      method(request, options, (err, response) => {
+        if (err) {
+          const code = err.code;
+          // Map gRPC status codes to domain exceptions
+          if (code === grpc.status.UNAVAILABLE ||
+              code === grpc.status.DEADLINE_EXCEEDED ||
+              code === grpc.status.RESOURCE_EXHAUSTED ||
+              code === grpc.status.CANCELLED) {
+            reject(new FreeplaneConnectionError(`gRPC call failed: ${err.details}`));
+          } else {
+            reject(new FreeplaneOperationError(
+              `gRPC call failed (${grpc.status[code] || code}): ${err.details}`
+            ));
+          }
+          return;
+        }
+
+        // Check the 'success' field common to most responses
+        if (response.success !== undefined && response.success !== null && !response.success) {
+          const errorMsg = response.errorMessage || response.error_message || '';
+          const message = errorMsg ? `Operation failed: ${errorMsg}` : 'Operation failed';
+          reject(new FreeplaneOperationError(message));
+          return;
+        }
+
+        resolve(response);
+      });
+    });
+  }
+
+  // ---- High-level operations ----
+
+  /**
+   * Get the currently open / active mind map.
+   * @returns {Promise<MindMap>}
+   */
+  async currentMap() {
+    const stub = this._getStub();
+    const resp = await this._call(stub.GetCurrentNode, {});
+    if (!resp.success) {
+      throw new FreeplaneOperationError(
+        resp.errorMessage || 'No map currently open'
+      );
+    }
+    return new MindMap(this, resp.mapId, resp.nodeId);
+  }
+
+  /**
+   * Alias for currentMap().
+   * @returns {Promise<MindMap>}
+   */
+  async selectedMap() {
+    return this.currentMap();
+  }
+
+  /**
+   * Open a mind map file on the Freeplane server.
+   * @param {string} filePath - Path to the .mm file to open.
+   * @returns {Promise<MindMap>}
+   */
+  async openMap(filePath) {
+    const stub = this._getStub();
+    await this._call(stub.OpenMap, { filePath });
+    return this.currentMap();
+  }
+
+  /**
+   * Export the current mind map as JSON.
+   * @returns {Promise<string>} JSON string.
+   */
+  async getMapToJson() {
+    const stub = this._getStub();
+    const resp = await this._call(stub.MindMapToJSON, {});
+    return resp.json;
+  }
+
+  /**
+   * Import a mind map from JSON data.
+   * @param {string} jsonData - JSON string representing a mind map.
+   * @returns {Promise<boolean>}
+   */
+  async mindMapFromJson(jsonData) {
+    const stub = this._getStub();
+    const resp = await this._call(stub.MindMapFromJSON, { json: jsonData });
+    return resp.success;
+  }
+
+  /**
+   * Execute Groovy code on the Freeplane server.
+   * @param {string} code - Groovy script to execute.
+   * @returns {Promise<string>} The result output.
+   */
+  async groovy(code) {
+    const stub = this._getStub();
+    const resp = await this._call(stub.Groovy, { groovyCode: code });
+    return resp.result;
+  }
+
+  /**
+   * Focus (select) a node in the Freeplane UI.
+   * @param {string} nodeId - ID of the node to focus.
+   * @returns {Promise<boolean>}
+   */
+  async focusNode(nodeId) {
+    const stub = this._getStub();
+    const resp = await this._call(stub.FocusNode, { nodeId });
+    return resp.success;
+  }
+
+  /**
+   * Set the status bar info in Freeplane.
+   * @param {string} info - Status text to display.
+   * @returns {Promise<boolean>}
+   */
+  async setStatusInfo(info) {
+    const stub = this._getStub();
+    const resp = await this._call(stub.StatusInfoSet, { statusInfo: info });
+    return resp.success;
+  }
+
+  // ---- Direct RPC wrappers (27 methods matching freeplane.proto) ----
+
+  async createChild(name, parentNodeId) {
+    const stub = this._getStub();
+    return this._call(stub.CreateChild, { name, parentNodeId });
+  }
+
+  async deleteChild(nodeId) {
+    const stub = this._getStub();
+    return this._call(stub.DeleteChild, { nodeId });
+  }
+
+  async nodeAttributeAdd(nodeId, attributeName, attributeValue) {
+    const stub = this._getStub();
+    return this._call(stub.NodeAttributeAdd, { nodeId, attributeName, attributeValue });
+  }
+
+  async nodeLinkSet(nodeId, link) {
+    const stub = this._getStub();
+    return this._call(stub.NodeLinkSet, { nodeId, link });
+  }
+
+  async nodeDetailsSet(nodeId, details) {
+    const stub = this._getStub();
+    return this._call(stub.NodeDetailsSet, { nodeId, details });
+  }
+
+  async nodeNoteSet(nodeId, note) {
+    const stub = this._getStub();
+    return this._call(stub.NodeNoteSet, { nodeId, note });
+  }
+
+  async nodeTagSet(nodeId, tags) {
+    const stub = this._getStub();
+    return this._call(stub.NodeTagSet, { nodeId, tags });
+  }
+
+  async nodeTagAdd(nodeId, tags) {
+    const stub = this._getStub();
+    return this._call(stub.NodeTagAdd, { nodeId, tags });
+  }
+
+  async nodeConnect(sourceNodeId, targetNodeId, relationship) {
+    const stub = this._getStub();
+    return this._call(stub.NodeConnect, { sourceNodeId, targetNodeId, relationship });
+  }
+
+  async nodeAddIcon(nodeId, iconName) {
+    const stub = this._getStub();
+    return this._call(stub.NodeAddIcon, { nodeId, iconName });
+  }
+
+  async nodeColorSet(nodeId, red, green, blue, alpha) {
+    const stub = this._getStub();
+    return this._call(stub.NodeColorSet, { nodeId, red, green, blue, alpha: alpha || 255 });
+  }
+
+  async nodeBackgroundColorSet(nodeId, red, green, blue, alpha) {
+    const stub = this._getStub();
+    return this._call(stub.NodeBackgroundColorSet, { nodeId, red, green, blue, alpha: alpha || 255 });
+  }
+
+  async textFSM(json) {
+    const stub = this._getStub();
+    return this._call(stub.TextFSM, { json });
+  }
+
+  async getNodeText(nodeId) {
+    const stub = this._getStub();
+    return this._call(stub.GetNodeText, { nodeId });
+  }
+
+  async getParentNode(nodeId) {
+    const stub = this._getStub();
+    return this._call(stub.GetParentNode, { nodeId });
+  }
+
+  async listChildNodes(nodeId) {
+    const stub = this._getStub();
+    return this._call(stub.ListChildNodes, { nodeId });
+  }
+
+  async getNodeNote(nodeId) {
+    const stub = this._getStub();
+    return this._call(stub.GetNodeNote, { nodeId });
+  }
+
+  async getNodeLink(nodeId) {
+    const stub = this._getStub();
+    return this._call(stub.GetNodeLink, { nodeId });
+  }
+
+  async setNodeText(nodeId, text) {
+    const stub = this._getStub();
+    return this._call(stub.SetNodeText, { nodeId, text });
+  }
+
+  async moveNode(nodeId, newParentNodeId) {
+    const stub = this._getStub();
+    return this._call(stub.MoveNode, { nodeId, newParentNodeId });
+  }
+}
+
+module.exports = FreeplaneClient;

--- a/grpc/nodejs/src/client.js
+++ b/grpc/nodejs/src/client.js
@@ -27,7 +27,6 @@ const DEFAULT_PORT = 50051;
 function loadProto() {
   const protoPath = path.join(__dirname, '..', '..', '..', 'src', 'main', 'proto', 'freeplane.proto');
   const packageDefinition = protoLoader.loadSync(protoPath, {
-    keepCase: true,
     longs: String,
     enums: String,
     defaults: true,
@@ -195,7 +194,7 @@ class FreeplaneClient {
         options.deadline = new Date(Date.now() + timeout);
       }
 
-      method(request, options, (err, response) => {
+      method.call(this._stub, request, options, (err, response) => {
         if (err) {
           const code = err.code;
           // Map gRPC status codes to domain exceptions

--- a/grpc/nodejs/src/client.js
+++ b/grpc/nodejs/src/client.js
@@ -90,26 +90,48 @@ class FreeplaneClient {
       this._stub = new freeplanePkg.freeplane.Freeplane(target, credentials);
       this._protoLoaded = true;
 
-      // Verify connectivity with a timeout
+      // Verify connectivity with a timeout.
+      // Use getConnectivityState(true) to trigger the connection attempt,
+      // then watch for state transitions until READY or timeout.
       await new Promise((resolve, reject) => {
         const deadline = Date.now() + 5000;
-        const checkConnectivity = () => {
+
+        // Trigger the channel to start connecting
+        this._channel.getConnectivityState(true);
+
+        const checkState = () => {
           const state = this._channel.getConnectivityState();
-          if (state === grpc.connectivityState.READY || state === grpc.connectivityState.IDLE) {
+          if (state === grpc.connectivityState.READY) {
             resolve();
+          } else if (state === grpc.connectivityState.TRANSIENT_FAILURE) {
+            // Server unreachable — retry by triggering another connection attempt
+            this._channel.getConnectivityState(true);
+            watchAndCheck();
           } else if (Date.now() >= deadline) {
             reject(new Error('timeout'));
           } else {
-            setTimeout(checkConnectivity, 100);
+            // CONNECTING or IDLE — keep watching
+            watchAndCheck();
           }
         };
-        this._channel.watchConnectivityState(grpc.connectivityState.IDLE, deadline, (err) => {
-          if (err) {
-            reject(err);
-          } else {
-            checkConnectivity();
-          }
-        });
+
+        const watchAndCheck = () => {
+          const currentState = this._channel.getConnectivityState();
+          this._channel.watchConnectivityState(currentState, deadline, (err) => {
+            if (err) {
+              // watch timeout — re-check in case deadline was extended
+              if (Date.now() >= deadline) {
+                reject(new Error('timeout'));
+              } else {
+                checkState();
+              }
+            } else {
+              checkState();
+            }
+          });
+        };
+
+        checkState();
       });
     } catch (err) {
       if (this._channel) {

--- a/grpc/nodejs/src/exceptions.js
+++ b/grpc/nodejs/src/exceptions.js
@@ -1,0 +1,73 @@
+/**
+ * Custom exception types for the freeplane-grpc-client library.
+ *
+ * Exception hierarchy:
+ *   FreeplaneGrpcError (base)
+ *     ├── FreeplaneConnectionError  (network/gRPC transport failures)
+ *     └── FreeplaneOperationError   (server-reported operation failures)
+ *           ├── NodeNotFoundError   (requested node does not exist)
+ *           └── MindMapError        (map-level operation failures)
+ */
+
+/**
+ * Base exception for all Freeplane gRPC errors.
+ * @extends Error
+ */
+class FreeplaneGrpcError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'FreeplaneGrpcError';
+  }
+}
+
+/**
+ * Raised when a connection to the Freeplane gRPC server fails.
+ * @extends FreeplaneGrpcError
+ */
+class FreeplaneConnectionError extends FreeplaneGrpcError {
+  constructor(message) {
+    super(message);
+    this.name = 'FreeplaneConnectionError';
+  }
+}
+
+/**
+ * Raised when a gRPC operation fails (server reported failure).
+ * @extends FreeplaneGrpcError
+ */
+class FreeplaneOperationError extends FreeplaneGrpcError {
+  constructor(message) {
+    super(message);
+    this.name = 'FreeplaneOperationError';
+  }
+}
+
+/**
+ * Raised when a requested node is not found.
+ * @extends FreeplaneOperationError
+ */
+class NodeNotFoundError extends FreeplaneOperationError {
+  constructor(message) {
+    super(message);
+    this.name = 'NodeNotFoundError';
+  }
+}
+
+/**
+ * Raised when a map-level operation fails.
+ * @extends FreeplaneOperationError
+ */
+class MindMapError extends FreeplaneOperationError {
+  constructor(message) {
+    super(message);
+    this.name = 'MindMapError';
+  }
+}
+
+module.exports = {
+  FreeplaneGrpcError,
+  FreeplaneConnectionError,
+  FreeplaneOperationError,
+  NodeNotFoundError,
+  MindMapError,
+};

--- a/grpc/nodejs/src/index.js
+++ b/grpc/nodejs/src/index.js
@@ -1,0 +1,32 @@
+/**
+ * freeplane-grpc-client - Node.js gRPC client for Freeplane
+ *
+ * Main entry point. Exports the FreeplaneClient, Node, MindMap classes
+ * and the exception hierarchy.
+ *
+ * Usage:
+ *   const { FreeplaneClient, Node, MindMap, FreeplaneGrpcError } = require('freeplane-grpc-client');
+ */
+
+const FreeplaneClient = require('./client');
+const Node = require('./node');
+const MindMap = require('./mindmap');
+
+const {
+  FreeplaneGrpcError,
+  FreeplaneConnectionError,
+  FreeplaneOperationError,
+  NodeNotFoundError,
+  MindMapError,
+} = require('./exceptions');
+
+module.exports = {
+  FreeplaneClient,
+  Node,
+  MindMap,
+  FreeplaneGrpcError,
+  FreeplaneConnectionError,
+  FreeplaneOperationError,
+  NodeNotFoundError,
+  MindMapError,
+};

--- a/grpc/nodejs/src/mindmap.js
+++ b/grpc/nodejs/src/mindmap.js
@@ -1,0 +1,236 @@
+/**
+ * MindMap - high-level representation of a Freeplane mind map.
+ *
+ * Provides map-level operations such as getting the root node,
+ * searching nodes, and exporting/importing the map.
+ */
+
+const { FreeplaneOperationError, NodeNotFoundError } = require('./exceptions');
+const Node = require('./node');
+
+/**
+ * Represents a Freeplane mind map.
+ */
+class MindMap {
+  /**
+   * Create a new MindMap instance.
+   * @param {FreeplaneClient} client - The FreeplaneClient to use for gRPC calls.
+   * @param {string} [mapId] - The ID of the mind map on the server.
+   * @param {string} [nodeId] - The ID of the currently focused/selected node.
+   */
+  constructor(client, mapId, nodeId) {
+    this._client = client;
+    this._mapId = mapId || '';
+    this._nodeId = nodeId || '';
+  }
+
+  get client() {
+    return this._client;
+  }
+
+  get mapId() {
+    return this._mapId;
+  }
+
+  get nodeId() {
+    return this._nodeId;
+  }
+
+  // ---- navigation ----
+
+  /**
+   * Get the root node of this mind map.
+   * @returns {Promise<Node>}
+   */
+  async root() {
+    let currentId = this._nodeId;
+    if (!currentId) {
+      const resp = await this._client._call(
+        this._client._getStub().GetCurrentNode, {}
+      );
+      if (resp.success) {
+        currentId = resp.nodeId;
+      } else {
+        throw new FreeplaneOperationError('No map currently open to get root from');
+      }
+    }
+
+    // Traverse up to find root
+    while (currentId) {
+      const parentResp = await this._client.getParentNode(currentId);
+      if (!parentResp.success || !parentResp.parentNodeId) {
+        return new Node(this._client, currentId, this);
+      }
+      currentId = parentResp.parentNodeId;
+    }
+
+    return new Node(this._client, this._nodeId, this);
+  }
+
+  /**
+   * Get the currently selected/focused node.
+   * @returns {Promise<Node>}
+   */
+  async selectedNode() {
+    const resp = await this._client._call(
+      this._client._getStub().GetCurrentNode, {}
+    );
+    if (!resp.success || !resp.nodeId) {
+      throw new FreeplaneOperationError('No node currently selected');
+    }
+    return new Node(this._client, resp.nodeId, this);
+  }
+
+  /**
+   * Find all nodes whose text contains the given pattern.
+   * @param {string} pattern - Text pattern to search for (case-insensitive).
+   * @returns {Promise<Node[]>}
+   */
+  async findNodes(pattern) {
+    const rootNode = await this.root();
+    const matches = [];
+    await this._walkAndCollect(rootNode, pattern, matches);
+    return matches;
+  }
+
+  /**
+   * Recursively walk the tree and collect matching nodes.
+   * @private
+   */
+  async _walkAndCollect(node, pattern, matches) {
+    try {
+      const text = await node.getText();
+      if (text.toLowerCase().includes(pattern.toLowerCase())) {
+        matches.push(node);
+      }
+    } catch (_) {
+      // Skip nodes we can't read
+    }
+
+    try {
+      const children = await node.children();
+      for (const child of children) {
+        await this._walkAndCollect(child, pattern, matches);
+      }
+    } catch (_) {
+      // No children or error accessing them
+    }
+  }
+
+  // ---- metadata ----
+
+  /**
+   * Get basic information about the current map.
+   * @returns {object}
+   */
+  info() {
+    return {
+      mapId: this._mapId,
+      nodeId: this._nodeId,
+    };
+  }
+
+  /**
+   * Estimate the number of nodes in the mind map.
+   * @returns {Promise<number>}
+   */
+  async size() {
+    const rootNode = await this.root();
+    return this._countNodes(rootNode);
+  }
+
+  /**
+   * Recursively count nodes.
+   * @private
+   */
+  async _countNodes(node) {
+    let count = 1;
+    try {
+      const children = await node.children();
+      for (const child of children) {
+        count += await this._countNodes(child);
+      }
+    } catch (_) {
+      // ignore
+    }
+    return count;
+  }
+
+  // ---- file operations ----
+
+  /**
+   * Save the current mind map.
+   * @param {string} [path] - Optional path to save to.
+   * @returns {Promise<boolean>}
+   */
+  async save(path) {
+    if (path) {
+      await this._client.groovy(
+        `model.getMap().getFile().setFile(new File("${path}"));` +
+        `model.getMap().getController().getUndoManager().undoableChanges(model.getMap());` +
+        `model.getMap().getController().getMapView().updateFileHistory(model.getMap());`
+      );
+    }
+    return true;
+  }
+
+  /**
+   * Export the current mind map to a file.
+   * @param {string} outputPath - Output file path.
+   * @param {string} [format='png'] - Export format.
+   * @returns {Promise<boolean>}
+   */
+  async export(outputPath, format) {
+    const fmt = format || 'png';
+    const result = await this._client.groovy(
+      `def controller = model.getMap().getController();` +
+      `def view = controller.getMapView();` +
+      `view.exportMap(new File('${outputPath}'), '${fmt}');`
+    );
+    return !result.includes('Error');
+  }
+
+  /**
+   * Import a mind map from a file.
+   * @param {string} filePath - Path to the map file.
+   * @returns {Promise<MindMap>}
+   */
+  async importMap(filePath) {
+    return this._client.openMap(filePath);
+  }
+
+  // ---- node creation ----
+
+  /**
+   * Create a new node in the mind map.
+   * @param {string} text - The node text.
+   * @param {string} [parentId] - ID of the parent node. If empty, creates under root.
+   * @returns {Promise<Node>}
+   */
+  async createNode(text, parentId) {
+    if (!parentId) {
+      const rootNode = await this.root();
+      parentId = rootNode.nodeId;
+    }
+    const resp = await this._client.createChild(text, parentId);
+    return new Node(this._client, resp.nodeId, this);
+  }
+
+  /**
+   * Create a child node under an existing node.
+   * @param {Node} parent - The parent Node instance.
+   * @param {string} text - The node text.
+   * @returns {Promise<Node>}
+   */
+  async createChild(parent, text) {
+    return this.createNode(text, parent.nodeId);
+  }
+
+  // ---- convenience ----
+
+  toString() {
+    return `MindMap(mapId=${this._mapId}, nodeId=${this._nodeId})`;
+  }
+}
+
+module.exports = MindMap;

--- a/grpc/nodejs/src/node.js
+++ b/grpc/nodejs/src/node.js
@@ -1,0 +1,406 @@
+/**
+ * Node - high-level representation of a Freeplane mind map node.
+ *
+ * Provides node-level operations such as getting/setting text,
+ * managing children, styling, notes, attributes, links, and icons.
+ */
+
+const { FreeplaneOperationError, NodeNotFoundError } = require('./exceptions');
+
+/**
+ * Represents a Freeplane mind map node.
+ */
+class Node {
+  /**
+   * Create a new Node instance.
+   * @param {FreeplaneClient} client - The FreeplaneClient to use for gRPC calls.
+   * @param {string} nodeId - The server-side node ID.
+   * @param {MindMap} [mindmap] - Optional parent MindMap reference.
+   */
+  constructor(client, nodeId, mindmap) {
+    this._client = client;
+    this._nodeId = nodeId;
+    this._mindmap = mindmap;
+  }
+
+  get client() {
+    return this._client;
+  }
+
+  get nodeId() {
+    return this._nodeId;
+  }
+
+  get mindmap() {
+    return this._mindmap;
+  }
+
+  // ---- text ----
+
+  /**
+   * Get the text of this node.
+   * @returns {Promise<string>}
+   */
+  async getText() {
+    const resp = await this._client.getNodeText(this._nodeId);
+    return resp.text;
+  }
+
+  /**
+   * Set the text of this node.
+   * @param {string} text - The new node text.
+   * @returns {Promise<void>}
+   */
+  async setText(text) {
+    await this._client.setNodeText(this._nodeId, text);
+  }
+
+  // ---- hierarchy ----
+
+  /**
+   * Add a child node to this node.
+   * @param {string} text - The child node text.
+   * @returns {Promise<Node>} The newly created child node.
+   */
+  async addChild(text) {
+    const resp = await this._client.createChild(text, this._nodeId);
+    const child = new Node(this._client, resp.nodeId, this._mindmap);
+    if (this._mindmap) {
+      this._mindmap._nodeId = resp.nodeId;
+    }
+    return child;
+  }
+
+  /**
+   * Get the direct children of this node.
+   * @returns {Promise<Node[]>}
+   */
+  async children() {
+    const resp = await this._client.listChildNodes(this._nodeId);
+    return (resp.children || []).map(child =>
+      new Node(this._client, child.nodeId, this._mindmap)
+    );
+  }
+
+  /**
+   * Get the parent of this node.
+   * @returns {Promise<Node>}
+   * @throws {NodeNotFoundError} If this node has no parent (is root).
+   */
+  async parent() {
+    const resp = await this._client.getParentNode(this._nodeId);
+    if (!resp.success || !resp.parentNodeId) {
+      throw new NodeNotFoundError(
+        `Node ${this._nodeId} has no parent (is root)`
+      );
+    }
+    return new Node(this._client, resp.parentNodeId, this._mindmap);
+  }
+
+  /**
+   * Delete this node.
+   * @returns {Promise<boolean>}
+   */
+  async delete() {
+    const resp = await this._client.deleteChild(this._nodeId);
+    return resp.success;
+  }
+
+  /**
+   * Move this node under a new parent.
+   * @param {string} newParentId - ID of the new parent node.
+   * @returns {Promise<boolean>}
+   */
+  async move(newParentId) {
+    const resp = await this._client.moveNode(this._nodeId, newParentId);
+    return resp.success;
+  }
+
+  // ---- styling ----
+
+  /**
+   * Get the style information for this node.
+   * @returns {Promise<object>}
+   */
+  async getStyle() {
+    const groovyCode = [
+      `def node = model.getNode('${this._nodeId}');`,
+      `def style = node.style;`,
+      `def result = [:];`,
+      `if (style != null) {`,
+      `  result = style.getProperties().collectEntries { k, v -> [k.toString(), v.toString()] }`,
+      `}`,
+    ].join('');
+    const result = await this._client.groovy(groovyCode);
+    return { style: result };
+  }
+
+  /**
+   * Set the style of this node.
+   * @param {string} style - Style name (e.g., "classic", "bubble", "flag").
+   * @returns {Promise<boolean>}
+   */
+  async setStyle(style) {
+    const groovyCode = [
+      `def node = model.getNode('${this._nodeId}');`,
+      `node.style = model.getStyleLib().getStyle('${style}');`,
+    ].join('');
+    const result = await this._client.groovy(groovyCode);
+    return !result.includes('Error');
+  }
+
+  /**
+   * Get the foreground color of this node.
+   * @returns {Promise<object>}
+   */
+  async getColor() {
+    const groovyCode = [
+      `def node = model.getNode('${this._nodeId}');`,
+      `def color = node.style.foregroundColor;`,
+      `color ? [red:color.red, green:color.green, blue:color.blue, alpha:color.alpha] : [:]`,
+    ].join('');
+    const result = await this._client.groovy(groovyCode);
+    return { color: result };
+  }
+
+  /**
+   * Set the foreground color of this node.
+   * @param {number} red
+   * @param {number} green
+   * @param {number} blue
+   * @param {number} [alpha=255]
+   * @returns {Promise<boolean>}
+   */
+  async setColor(red, green, blue, alpha) {
+    const resp = await this._client.nodeColorSet(this._nodeId, red, green, blue, alpha);
+    return resp.success;
+  }
+
+  /**
+   * Get the background color of this node.
+   * @returns {Promise<object>}
+   */
+  async getBackgroundColor() {
+    const groovyCode = [
+      `def node = model.getNode('${this._nodeId}');`,
+      `def color = node.style.backgroundColor;`,
+      `color ? [red:color.red, green:color.green, blue:color.blue, alpha:color.alpha] : [:]`,
+    ].join('');
+    const result = await this._client.groovy(groovyCode);
+    return { backgroundColor: result };
+  }
+
+  /**
+   * Set the background color of this node.
+   * @param {number} red
+   * @param {number} green
+   * @param {number} blue
+   * @param {number} [alpha=255]
+   * @returns {Promise<boolean>}
+   */
+  async setBackgroundColor(red, green, blue, alpha) {
+    const resp = await this._client.nodeBackgroundColorSet(this._nodeId, red, green, blue, alpha);
+    return resp.success;
+  }
+
+  // ---- notes ----
+
+  /**
+   * Get the note of this node.
+   * @returns {Promise<string>}
+   */
+  async getNote() {
+    const resp = await this._client.getNodeNote(this._nodeId);
+    return resp.note;
+  }
+
+  /**
+   * Set the note of this node.
+   * @param {string} note
+   * @returns {Promise<boolean>}
+   */
+  async setNote(note) {
+    const resp = await this._client.nodeNoteSet(this._nodeId, note);
+    return resp.success;
+  }
+
+  // ---- attributes ----
+
+  /**
+   * Get the attributes of this node.
+   * @returns {Promise<object>}
+   */
+  async getAttributes() {
+    const groovyCode = [
+      `def node = model.getNode('${this._nodeId}');`,
+      `def attrs = node.attributes;`,
+      `attrs ? attrs.collectEntries { k, v -> [k.toString(), v.toString()] } : [:]`,
+    ].join('');
+    const result = await this._client.groovy(groovyCode);
+    return { attributes: result };
+  }
+
+  /**
+   * Set a custom attribute on this node.
+   * @param {string} name - Attribute name.
+   * @param {string} value - Attribute value.
+   * @returns {Promise<boolean>}
+   */
+  async setAttribute(name, value) {
+    const resp = await this._client.nodeAttributeAdd(this._nodeId, name, value);
+    return resp.success;
+  }
+
+  /**
+   * Set multiple custom attributes on this node.
+   * @param {object} attrs - Dictionary of attribute name-value pairs.
+   * @returns {Promise<boolean>}
+   */
+  async setAttributes(attrs) {
+    for (const [name, value] of Object.entries(attrs)) {
+      const result = await this.setAttribute(name, String(value));
+      if (!result) return false;
+    }
+    return true;
+  }
+
+  // ---- links ----
+
+  /**
+   * Get the links of this node.
+   * @returns {Promise<string[]>}
+   */
+  async getLinks() {
+    const resp = await this._client.getNodeLink(this._nodeId);
+    return resp.hasLink ? [resp.link] : [];
+  }
+
+  /**
+   * Set the links of this node (replaces existing links).
+   * @param {string[]} links - List of link URLs.
+   * @returns {Promise<boolean>}
+   */
+  async setLinks(links) {
+    for (const link of links) {
+      await this._client.nodeLinkSet(this._nodeId, link);
+    }
+    return true;
+  }
+
+  // ---- tags ----
+
+  /**
+   * Set the tags of this node (replaces existing tags).
+   * @param {string[]} tags - List of tag strings.
+   * @returns {Promise<boolean>}
+   */
+  async setTags(tags) {
+    const resp = await this._client.nodeTagSet(this._nodeId, tags);
+    return resp.success;
+  }
+
+  /**
+   * Add tags to this node (does not remove existing tags).
+   * @param {string[]} tags - List of tag strings to add.
+   * @returns {Promise<boolean>}
+   */
+  async addTags(tags) {
+    const resp = await this._client.nodeTagAdd(this._nodeId, tags);
+    return resp.success;
+  }
+
+  // ---- icons ----
+
+  /**
+   * Get the icons of this node.
+   * @returns {Promise<object>}
+   */
+  async getIcons() {
+    const groovyCode = [
+      `def node = model.getNode('${this._nodeId}');`,
+      `def icons = node.getIconIds();`,
+      `icons ? icons.toList() : []`,
+    ].join('');
+    const result = await this._client.groovy(groovyCode);
+    return { icons: result };
+  }
+
+  /**
+   * Add an icon to this node.
+   * @param {string} iconName - Name of the icon to add.
+   * @returns {Promise<boolean>}
+   */
+  async addIcon(iconName) {
+    const resp = await this._client.nodeAddIcon(this._nodeId, iconName);
+    return resp.success;
+  }
+
+  // ---- state ----
+
+  /**
+   * Get the folded (collapsed) state of this node.
+   * @returns {Promise<boolean>}
+   */
+  async getFolded() {
+    const groovyCode = [
+      `def node = model.getNode('${this._nodeId}');`,
+      `node.isFolded()`,
+    ].join('');
+    const result = await this._client.groovy(groovyCode);
+    return result.toLowerCase().includes('true');
+  }
+
+  /**
+   * Set the folded (collapsed) state of this node.
+   * @param {boolean} folded - True to fold, false to unfold.
+   * @returns {Promise<boolean>}
+   */
+  async setFolded(folded) {
+    const groovyCode = [
+      `def node = model.getNode('${this._nodeId}');`,
+      `if (${folded}) node.fold() else node.unfold();`,
+    ].join('');
+    const result = await this._client.groovy(groovyCode);
+    return !result.includes('Error');
+  }
+
+  // ---- actions ----
+
+  /**
+   * Select this node in the Freeplane UI.
+   * @returns {Promise<boolean>}
+   */
+  async select() {
+    return this._client.focusNode(this._nodeId);
+  }
+
+  /**
+   * Center the view on this node.
+   * @returns {Promise<boolean>}
+   */
+  async center() {
+    return this._client.focusNode(this._nodeId);
+  }
+
+  // ---- refresh ----
+
+  /**
+   * Reload this node's state from the server.
+   * @returns {Promise<void>}
+   */
+  async refresh() {
+    await this.getText();
+  }
+
+  // ---- convenience ----
+
+  toString() {
+    return `Node(id=${this._nodeId})`;
+  }
+
+  valueOf() {
+    return this._nodeId;
+  }
+}
+
+module.exports = Node;

--- a/grpc/nodejs/test/integration/client.test.js
+++ b/grpc/nodejs/test/integration/client.test.js
@@ -1,0 +1,175 @@
+/**
+ * Integration tests for FreeplaneClient.
+ * Skipped when FREEPLANE_HOST is not set.
+ */
+
+const { getRealClient, uniqueName, shouldRunIntegration } = require('./integration-helper');
+
+const describeInt = shouldRunIntegration() ? describe : describe.skip;
+
+describeInt('FreeplaneClient Integration', () => {
+  let client;
+
+  beforeAll(async () => {
+    client = getRealClient();
+    await client.connect();
+  }, 30000);
+
+  afterAll(async () => {
+    if (client) {
+      await client.close();
+    }
+  }, 10000);
+
+  test('can get current map', async () => {
+    const map = await client.currentMap();
+    expect(map).toBeDefined();
+    expect(map.mapId).toBeDefined();
+  }, 15000);
+
+  test('can create and read a child node', async () => {
+    const map = await client.currentMap();
+    const root = await map.root();
+    const name = uniqueName('IT');
+    const child = await root.addChild(name);
+    expect(child.nodeId).toBeDefined();
+
+    const text = await child.getText();
+    expect(text).toBe(name);
+
+    // Cleanup
+    await child.delete();
+  }, 15000);
+
+  test('can set and get node text', async () => {
+    const map = await client.currentMap();
+    const root = await map.root();
+    const name = uniqueName('IT');
+    const child = await root.addChild(name);
+
+    await child.setText('Modified Text');
+    const text = await child.getText();
+    expect(text).toBe('Modified Text');
+
+    // Cleanup
+    await child.delete();
+  }, 15000);
+
+  test('can list children', async () => {
+    const map = await client.currentMap();
+    const root = await map.root();
+    const name1 = uniqueName('IT');
+    const name2 = uniqueName('IT');
+
+    const child1 = await root.addChild(name1);
+    const child2 = await root.addChild(name2);
+
+    const children = await root.children();
+    const childIds = children.map(c => c.nodeId);
+    expect(childIds).toContain(child1.nodeId);
+    expect(childIds).toContain(child2.nodeId);
+
+    // Cleanup
+    await child1.delete();
+    await child2.delete();
+  }, 15000);
+
+  test('can get parent node', async () => {
+    const map = await client.currentMap();
+    const root = await map.root();
+    const name = uniqueName('IT');
+    const child = await root.addChild(name);
+
+    const parent = await child.parent();
+    expect(parent.nodeId).toBe(root.nodeId);
+
+    // Cleanup
+    await child.delete();
+  }, 15000);
+
+  test('can set and get node note', async () => {
+    const map = await client.currentMap();
+    const root = await map.root();
+    const name = uniqueName('IT');
+    const child = await root.addChild(name);
+
+    await child.setNote('Integration test note');
+    const note = await child.getNote();
+    expect(note).toBe('Integration test note');
+
+    // Cleanup
+    await child.delete();
+  }, 15000);
+
+  test('can set and get node tags', async () => {
+    const map = await client.currentMap();
+    const root = await map.root();
+    const name = uniqueName('IT');
+    const child = await root.addChild(name);
+
+    await child.setTags(['tag1', 'tag2']);
+
+    // Cleanup
+    await child.delete();
+  }, 15000);
+
+  test('can add tags to node', async () => {
+    const map = await client.currentMap();
+    const root = await map.root();
+    const name = uniqueName('IT');
+    const child = await root.addChild(name);
+
+    await child.addTags(['extra-tag']);
+
+    // Cleanup
+    await child.delete();
+  }, 15000);
+
+  test('can set node color', async () => {
+    const map = await client.currentMap();
+    const root = await map.root();
+    const name = uniqueName('IT');
+    const child = await root.addChild(name);
+
+    const result = await child.setColor(255, 0, 0, 255);
+    expect(result).toBe(true);
+
+    // Cleanup
+    await child.delete();
+  }, 15000);
+
+  test('can set node attribute', async () => {
+    const map = await client.currentMap();
+    const root = await map.root();
+    const name = uniqueName('IT');
+    const child = await root.addChild(name);
+
+    const result = await child.setAttribute('test-key', 'test-value');
+    expect(result).toBe(true);
+
+    // Cleanup
+    await child.delete();
+  }, 15000);
+
+  test('can export and import JSON', async () => {
+    const json = await client.getMapToJson();
+    expect(json).toBeDefined();
+    expect(json.length).toBeGreaterThan(0);
+
+    // Parse to verify it's valid JSON
+    const parsed = JSON.parse(json);
+    expect(parsed).toBeDefined();
+  }, 15000);
+
+  test('can set status info', async () => {
+    const result = await client.setStatusInfo('Integration test status');
+    expect(result).toBe(true);
+  }, 15000);
+
+  test('can focus a node', async () => {
+    const map = await client.currentMap();
+    const root = await map.root();
+    const result = await client.focusNode(root.nodeId);
+    expect(result).toBe(true);
+  }, 15000);
+});

--- a/grpc/nodejs/test/integration/integration-helper.js
+++ b/grpc/nodejs/test/integration/integration-helper.js
@@ -1,0 +1,50 @@
+/**
+ * Shared setup/teardown for integration tests.
+ * Requires a running Freeplane gRPC server.
+ *
+ * Environment variables:
+ *   FREEPLANE_HOST  — server host (default: 127.0.0.1)
+ *   FREEPLANE_PORT  — server port  (default: 50051)
+ */
+
+const FreeplaneClient = require('../../src/client');
+
+let sharedClient = null;
+
+/**
+ * Get a shared client instance for integration tests.
+ * @returns {FreeplaneClient}
+ */
+function getRealClient() {
+  if (!sharedClient) {
+    sharedClient = new FreeplaneClient({
+      host: process.env.FREEPLANE_HOST || '127.0.0.1',
+      port: parseInt(process.env.FREEPLANE_PORT, 10) || 50051,
+    });
+  }
+  return sharedClient;
+}
+
+/**
+ * Generate a unique name for test nodes.
+ * @param {string} [prefix='IT']
+ * @returns {string}
+ */
+function uniqueName(prefix) {
+  const p = prefix || 'IT';
+  return `${p}_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
+}
+
+/**
+ * Check if integration tests should run.
+ * @returns {boolean}
+ */
+function shouldRunIntegration() {
+  return !!process.env.FREEPLANE_HOST;
+}
+
+module.exports = {
+  getRealClient,
+  uniqueName,
+  shouldRunIntegration,
+};

--- a/grpc/nodejs/test/integration/mindmap.test.js
+++ b/grpc/nodejs/test/integration/mindmap.test.js
@@ -1,0 +1,75 @@
+/**
+ * Integration tests for MindMap class.
+ * Skipped when FREEPLANE_HOST is not set.
+ */
+
+const { getRealClient, uniqueName, shouldRunIntegration } = require('./integration-helper');
+
+const describeInt = shouldRunIntegration() ? describe : describe.skip;
+
+describeInt('MindMap Integration', () => {
+  let client;
+
+  beforeAll(async () => {
+    client = getRealClient();
+    await client.connect();
+  }, 30000);
+
+  afterAll(async () => {
+    if (client) {
+      await client.close();
+    }
+  }, 10000);
+
+  test('currentMap returns a MindMap', async () => {
+    const map = await client.currentMap();
+    expect(map).toBeDefined();
+    expect(map.mapId).toBeDefined();
+  });
+
+  test('root returns the root node', async () => {
+    const map = await client.currentMap();
+    const root = await map.root();
+    expect(root.nodeId).toBeDefined();
+  });
+
+  test('selectedNode returns the selected node', async () => {
+    const map = await client.currentMap();
+    const node = await map.selectedNode();
+    expect(node.nodeId).toBeDefined();
+  });
+
+  test('createNode creates a node under root', async () => {
+    const map = await client.currentMap();
+    const name = uniqueName('MM');
+    const node = await map.createNode(name);
+    expect(node.nodeId).toBeDefined();
+    const text = await node.getText();
+    expect(text).toBe(name);
+    await node.delete();
+  });
+
+  test('findNodes finds matching nodes', async () => {
+    const map = await client.currentMap();
+    const name = uniqueName('FindMe');
+    const root = await map.root();
+    const node = await root.addChild(name);
+
+    const results = await map.findNodes('FindMe');
+    expect(results.length).toBeGreaterThanOrEqual(1);
+
+    await node.delete();
+  });
+
+  test('info returns map metadata', async () => {
+    const map = await client.currentMap();
+    const info = map.info();
+    expect(info).toHaveProperty('mapId');
+    expect(info).toHaveProperty('nodeId');
+  });
+
+  test('toString returns formatted string', async () => {
+    const map = await client.currentMap();
+    expect(map.toString()).toContain('MindMap(');
+  });
+});

--- a/grpc/nodejs/test/integration/node.test.js
+++ b/grpc/nodejs/test/integration/node.test.js
@@ -1,0 +1,119 @@
+/**
+ * Integration tests for Node class.
+ * Skipped when FREEPLANE_HOST is not set.
+ */
+
+const { getRealClient, uniqueName, shouldRunIntegration } = require('./integration-helper');
+
+const describeInt = shouldRunIntegration() ? describe : describe.skip;
+
+describeInt('Node Integration', () => {
+  let client;
+  let testNode;
+
+  beforeAll(async () => {
+    client = getRealClient();
+    await client.connect();
+  }, 30000);
+
+  beforeEach(async () => {
+    const map = await client.currentMap();
+    const root = await map.root();
+    testNode = await root.addChild(uniqueName('NodeIT'));
+  }, 15000);
+
+  afterEach(async () => {
+    if (testNode) {
+      try {
+        await testNode.delete();
+      } catch (_) {
+        // ignore cleanup errors
+      }
+    }
+  }, 10000);
+
+  afterAll(async () => {
+    if (client) {
+      await client.close();
+    }
+  }, 10000);
+
+  test('getText returns the node text', async () => {
+    const text = await testNode.getText();
+    expect(text).toContain('NodeIT');
+  });
+
+  test('setText updates the node text', async () => {
+    await testNode.setText('Updated Integration Text');
+    const text = await testNode.getText();
+    expect(text).toBe('Updated Integration Text');
+  });
+
+  test('addChild creates a child and returns Node', async () => {
+    const child = await testNode.addChild('Grandchild');
+    expect(child.nodeId).toBeDefined();
+    const text = await child.getText();
+    expect(text).toBe('Grandchild');
+    await child.delete();
+  });
+
+  test('children returns child nodes', async () => {
+    const c1 = await testNode.addChild('Child1');
+    const c2 = await testNode.addChild('Child2');
+    const children = await testNode.children();
+    expect(children.length).toBeGreaterThanOrEqual(2);
+    await c1.delete();
+    await c2.delete();
+  });
+
+  test('parent returns the parent node', async () => {
+    const parent = await testNode.parent();
+    expect(parent.nodeId).toBeDefined();
+    expect(parent.nodeId).not.toBe(testNode.nodeId);
+  });
+
+  test('setNote and getNote work', async () => {
+    await testNode.setNote('Integration note content');
+    const note = await testNode.getNote();
+    expect(note).toBe('Integration note content');
+  });
+
+  test('setAttribute works', async () => {
+    const result = await testNode.setAttribute('int-key', 'int-value');
+    expect(result).toBe(true);
+  });
+
+  test('setTags works', async () => {
+    const result = await testNode.setTags(['int-tag1', 'int-tag2']);
+    expect(result).toBe(true);
+  });
+
+  test('addTags works', async () => {
+    const result = await testNode.addTags(['int-extra']);
+    expect(result).toBe(true);
+  });
+
+  test('setColor works', async () => {
+    const result = await testNode.setColor(0, 128, 255, 255);
+    expect(result).toBe(true);
+  });
+
+  test('setBackgroundColor works', async () => {
+    const result = await testNode.setBackgroundColor(255, 255, 0, 200);
+    expect(result).toBe(true);
+  });
+
+  test('select focuses the node', async () => {
+    const result = await testNode.select();
+    expect(result).toBe(true);
+  });
+
+  test('refresh reloads node state', async () => {
+    await testNode.refresh();
+    // Should not throw
+  });
+
+  test('toString returns formatted string', () => {
+    expect(testNode.toString()).toContain('Node(id=');
+  });
+});

--- a/grpc/nodejs/test/unit/client.test.js
+++ b/grpc/nodejs/test/unit/client.test.js
@@ -1,0 +1,228 @@
+/**
+ * Unit tests for FreeplaneClient.
+ * All tests are mocked — no Freeplane server required.
+ */
+
+const FreeplaneClient = require('../../src/client');
+const {
+  FreeplaneConnectionError,
+  FreeplaneOperationError,
+} = require('../../src/exceptions');
+
+describe('FreeplaneClient', () => {
+  describe('constructor', () => {
+    test('uses default host and port', () => {
+      const client = new FreeplaneClient();
+      expect(client.host).toBe('127.0.0.1');
+      expect(client.port).toBe(50051);
+    });
+
+    test('accepts custom host and port', () => {
+      const client = new FreeplaneClient({ host: '10.0.0.1', port: 9999 });
+      expect(client.host).toBe('10.0.0.1');
+      expect(client.port).toBe(9999);
+    });
+
+    test('reads FREEPLANE_HOST from environment', () => {
+      const origHost = process.env.FREEPLANE_HOST;
+      process.env.FREEPLANE_HOST = 'env-host';
+      const client = new FreeplaneClient();
+      expect(client.host).toBe('env-host');
+      if (origHost === undefined) {
+        delete process.env.FREEPLANE_HOST;
+      } else {
+        process.env.FREEPLANE_HOST = origHost;
+      }
+    });
+
+    test('reads FREEPLANE_PORT from environment', () => {
+      const origPort = process.env.FREEPLANE_PORT;
+      process.env.FREEPLANE_PORT = '7777';
+      const client = new FreeplaneClient();
+      expect(client.port).toBe(7777);
+      if (origPort === undefined) {
+        delete process.env.FREEPLANE_PORT;
+      } else {
+        process.env.FREEPLANE_PORT = origPort;
+      }
+    });
+
+    test('constructor options override environment variables', () => {
+      const origHost = process.env.FREEPLANE_HOST;
+      process.env.FREEPLANE_HOST = 'env-host';
+      const client = new FreeplaneClient({ host: 'opt-host' });
+      expect(client.host).toBe('opt-host');
+      if (origHost === undefined) {
+        delete process.env.FREEPLANE_HOST;
+      } else {
+        process.env.FREEPLANE_HOST = origHost;
+      }
+    });
+  });
+
+  describe('close', () => {
+    test('does not throw when channel is null', async () => {
+      const client = new FreeplaneClient();
+      await expect(client.close()).resolves.toBeUndefined();
+    });
+
+    test('clears stub reference', async () => {
+      const client = new FreeplaneClient();
+      client._stub = { some: 'stub' };
+      await client.close();
+      expect(client._stub).toBeNull();
+    });
+  });
+
+  describe('_getStub', () => {
+    test('throws FreeplaneConnectionError when not connected', () => {
+      const client = new FreeplaneClient();
+      expect(() => client._getStub()).toThrow(FreeplaneConnectionError);
+    });
+
+    test('returns stub when connected', () => {
+      const client = new FreeplaneClient();
+      client._stub = { test: true };
+      expect(client._getStub()).toEqual({ test: true });
+    });
+  });
+
+  describe('_call', () => {
+    test('resolves with response on success', async () => {
+      const client = new FreeplaneClient();
+      const mockMethod = jest.fn((req, opts, callback) => {
+        callback(null, { success: true, data: 'ok' });
+      });
+      const result = await client._call(mockMethod, { test: true });
+      expect(result).toEqual({ success: true, data: 'ok' });
+      expect(mockMethod).toHaveBeenCalledWith({ test: true }, {}, expect.any(Function));
+    });
+
+    test('rejects with FreeplaneOperationError when success is false', async () => {
+      const client = new FreeplaneClient();
+      const mockMethod = jest.fn((req, opts, callback) => {
+        callback(null, { success: false, errorMessage: 'bad thing' });
+      });
+      await expect(client._call(mockMethod, {})).rejects.toThrow(FreeplaneOperationError);
+    });
+
+    test('rejects with FreeplaneConnectionError on UNAVAILABLE', async () => {
+      const client = new FreeplaneClient();
+      const mockErr = { code: 14, details: 'Server unavailable' }; // UNAVAILABLE
+      const mockMethod = jest.fn((req, opts, callback) => {
+        callback(mockErr);
+      });
+      await expect(client._call(mockMethod, {})).rejects.toThrow(FreeplaneConnectionError);
+    });
+
+    test('rejects with FreeplaneConnectionError on DEADLINE_EXCEEDED', async () => {
+      const client = new FreeplaneClient();
+      const mockErr = { code: 4, details: 'Deadline exceeded' };
+      const mockMethod = jest.fn((req, opts, callback) => {
+        callback(mockErr);
+      });
+      await expect(client._call(mockMethod, {})).rejects.toThrow(FreeplaneConnectionError);
+    });
+
+    test('rejects with FreeplaneOperationError on OTHER errors', async () => {
+      const client = new FreeplaneClient();
+      const mockErr = { code: 2, details: 'Not found' }; // NOT_FOUND
+      const mockMethod = jest.fn((req, opts, callback) => {
+        callback(mockErr);
+      });
+      await expect(client._call(mockMethod, {})).rejects.toThrow(FreeplaneOperationError);
+    });
+
+    test('passes timeout as deadline option', async () => {
+      const client = new FreeplaneClient();
+      const mockMethod = jest.fn((req, opts, callback) => {
+        callback(null, { success: true });
+      });
+      await client._call(mockMethod, {}, 5000);
+      expect(mockMethod).toHaveBeenCalledWith({}, expect.objectContaining({ deadline: expect.any(Date) }), expect.any(Function));
+    });
+
+    test('does not set deadline when no timeout provided', async () => {
+      const client = new FreeplaneClient();
+      const mockMethod = jest.fn((req, opts, callback) => {
+        callback(null, { success: true });
+      });
+      await client._call(mockMethod, {});
+      const callOpts = mockMethod.mock.calls[0][1];
+      expect(callOpts).toEqual({});
+    });
+  });
+
+  describe('RPC wrappers', () => {
+    let client;
+    let mockStub;
+
+    beforeEach(() => {
+      client = new FreeplaneClient();
+      mockStub = {};
+      client._stub = mockStub;
+    });
+
+    const rpcMethods = [
+      { name: 'createChild', stubMethod: 'CreateChild', args: ['child', 'parent1'] },
+      { name: 'deleteChild', stubMethod: 'DeleteChild', args: ['node1'] },
+      { name: 'nodeAttributeAdd', stubMethod: 'NodeAttributeAdd', args: ['node1', 'key', 'val'] },
+      { name: 'nodeLinkSet', stubMethod: 'NodeLinkSet', args: ['node1', 'http://example.com'] },
+      { name: 'nodeDetailsSet', stubMethod: 'NodeDetailsSet', args: ['node1', 'details'] },
+      { name: 'nodeNoteSet', stubMethod: 'NodeNoteSet', args: ['node1', 'note'] },
+      { name: 'nodeTagSet', stubMethod: 'NodeTagSet', args: ['node1', ['tag1']] },
+      { name: 'nodeTagAdd', stubMethod: 'NodeTagAdd', args: ['node1', ['tag1']] },
+      { name: 'nodeConnect', stubMethod: 'NodeConnect', args: ['src', 'tgt', 'rel'] },
+      { name: 'nodeAddIcon', stubMethod: 'NodeAddIcon', args: ['node1', 'flag'] },
+      { name: 'nodeColorSet', stubMethod: 'NodeColorSet', args: ['node1', 255, 0, 0] },
+      { name: 'nodeBackgroundColorSet', stubMethod: 'NodeBackgroundColorSet', args: ['node1', 0, 255, 0] },
+      { name: 'textFSM', stubMethod: 'TextFSM', args: ['{}'] },
+      { name: 'getNodeText', stubMethod: 'GetNodeText', args: ['node1'] },
+      { name: 'getParentNode', stubMethod: 'GetParentNode', args: ['node1'] },
+      { name: 'listChildNodes', stubMethod: 'ListChildNodes', args: ['node1'] },
+      { name: 'getNodeNote', stubMethod: 'GetNodeNote', args: ['node1'] },
+      { name: 'getNodeLink', stubMethod: 'GetNodeLink', args: ['node1'] },
+      { name: 'setNodeText', stubMethod: 'SetNodeText', args: ['node1', 'text'] },
+      { name: 'moveNode', stubMethod: 'MoveNode', args: ['node1', 'parent1'] },
+    ];
+
+    rpcMethods.forEach(({ name, stubMethod, args }) => {
+      test(`${name} calls the correct stub method`, async () => {
+        const mockFn = jest.fn((req, opts, cb) => cb(null, { success: true }));
+        mockStub[stubMethod] = mockFn;
+
+        await client[name](...args);
+        expect(mockFn).toHaveBeenCalled();
+      });
+    });
+
+    test('groovy calls the Groovy stub method', async () => {
+      const mockFn = jest.fn((req, opts, cb) => cb(null, { success: true, result: 'output' }));
+      mockStub.Groovy = mockFn;
+
+      const result = await client.groovy('println "hello"');
+      expect(result).toBe('output');
+      expect(mockFn).toHaveBeenCalledWith(
+        { groovyCode: 'println "hello"' },
+        {},
+        expect.any(Function)
+      );
+    });
+
+    test('focusNode calls the FocusNode stub method', async () => {
+      const mockFn = jest.fn((req, opts, cb) => cb(null, { success: true }));
+      mockStub.FocusNode = mockFn;
+
+      const result = await client.focusNode('node1');
+      expect(result).toBe(true);
+    });
+
+    test('setStatusInfo calls the StatusInfoSet stub method', async () => {
+      const mockFn = jest.fn((req, opts, cb) => cb(null, { success: true }));
+      mockStub.StatusInfoSet = mockFn;
+
+      const result = await client.setStatusInfo('hello');
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/grpc/nodejs/test/unit/exceptions.test.js
+++ b/grpc/nodejs/test/unit/exceptions.test.js
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for the exception hierarchy.
+ */
+
+const {
+  FreeplaneGrpcError,
+  FreeplaneConnectionError,
+  FreeplaneOperationError,
+  NodeNotFoundError,
+  MindMapError,
+} = require('../../src/exceptions');
+
+describe('FreeplaneGrpcError', () => {
+  test('is an Error subclass', () => {
+    const err = new FreeplaneGrpcError('test');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(FreeplaneGrpcError);
+    expect(err.message).toBe('test');
+    expect(err.name).toBe('FreeplaneGrpcError');
+  });
+});
+
+describe('FreeplaneConnectionError', () => {
+  test('extends FreeplaneGrpcError', () => {
+    const err = new FreeplaneConnectionError('conn failed');
+    expect(err).toBeInstanceOf(FreeplaneGrpcError);
+    expect(err).toBeInstanceOf(FreeplaneConnectionError);
+    expect(err.message).toBe('conn failed');
+    expect(err.name).toBe('FreeplaneConnectionError');
+  });
+
+  test('does not extend FreeplaneOperationError', () => {
+    const err = new FreeplaneConnectionError('conn failed');
+    expect(err).not.toBeInstanceOf(FreeplaneOperationError);
+  });
+});
+
+describe('FreeplaneOperationError', () => {
+  test('extends FreeplaneGrpcError', () => {
+    const err = new FreeplaneOperationError('op failed');
+    expect(err).toBeInstanceOf(FreeplaneGrpcError);
+    expect(err).toBeInstanceOf(FreeplaneOperationError);
+    expect(err.message).toBe('op failed');
+    expect(err.name).toBe('FreeplaneOperationError');
+  });
+});
+
+describe('NodeNotFoundError', () => {
+  test('extends FreeplaneOperationError', () => {
+    const err = new NodeNotFoundError('node not found');
+    expect(err).toBeInstanceOf(FreeplaneOperationError);
+    expect(err).toBeInstanceOf(FreeplaneGrpcError);
+    expect(err).toBeInstanceOf(NodeNotFoundError);
+    expect(err.message).toBe('node not found');
+    expect(err.name).toBe('NodeNotFoundError');
+  });
+});
+
+describe('MindMapError', () => {
+  test('extends FreeplaneOperationError', () => {
+    const err = new MindMapError('map error');
+    expect(err).toBeInstanceOf(FreeplaneOperationError);
+    expect(err).toBeInstanceOf(FreeplaneGrpcError);
+    expect(err).toBeInstanceOf(MindMapError);
+    expect(err.message).toBe('map error');
+    expect(err.name).toBe('MindMapError');
+  });
+});
+
+describe('exception hierarchy completeness', () => {
+  test('all exceptions are Error instances', () => {
+    const errors = [
+      new FreeplaneGrpcError('a'),
+      new FreeplaneConnectionError('b'),
+      new FreeplaneOperationError('c'),
+      new NodeNotFoundError('d'),
+      new MindMapError('e'),
+    ];
+    errors.forEach(err => {
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toHaveProperty('message');
+      expect(err).toHaveProperty('name');
+    });
+  });
+
+  test('can catch base class for all derived types', () => {
+    const errors = [
+      new FreeplaneConnectionError('a'),
+      new FreeplaneOperationError('b'),
+      new NodeNotFoundError('c'),
+      new MindMapError('d'),
+    ];
+    errors.forEach(err => {
+      expect(() => {
+        if (err instanceof FreeplaneGrpcError) throw err;
+      }).toThrow(FreeplaneGrpcError);
+    });
+  });
+});

--- a/grpc/nodejs/test/unit/mindmap.test.js
+++ b/grpc/nodejs/test/unit/mindmap.test.js
@@ -1,0 +1,207 @@
+/**
+ * Unit tests for MindMap class.
+ * All tests are mocked — no Freeplane server required.
+ */
+
+const MindMap = require('../../src/mindmap');
+const Node = require('../../src/node');
+const { FreeplaneOperationError } = require('../../src/exceptions');
+
+describe('MindMap', () => {
+  let mockClient;
+
+  beforeEach(() => {
+    mockClient = {
+      getCurrentNode: jest.fn(),
+      getParentNode: jest.fn(),
+      createChild: jest.fn(),
+      groovy: jest.fn(),
+      openMap: jest.fn(),
+      _getStub: jest.fn(),
+      _call: jest.fn(),
+    };
+  });
+
+  describe('constructor and properties', () => {
+    test('stores client, mapId, and nodeId', () => {
+      const mm = new MindMap(mockClient, 'map1', 'node1');
+      expect(mm.client).toBe(mockClient);
+      expect(mm.mapId).toBe('map1');
+      expect(mm.nodeId).toBe('node1');
+    });
+
+    test('defaults to empty strings when not provided', () => {
+      const mm = new MindMap(mockClient);
+      expect(mm.mapId).toBe('');
+      expect(mm.nodeId).toBe('');
+    });
+  });
+
+  describe('root', () => {
+    test('traverses up to find root node', async () => {
+      // First call: node1 has parent parent1
+      // Second call: parent1 has no parent (is root)
+      mockClient.getParentNode
+        .mockResolvedValueOnce({ success: true, parentNodeId: 'parent1' })
+        .mockResolvedValueOnce({ success: true, parentNodeId: '' });
+
+      const mm = new MindMap(mockClient, 'map1', 'node1');
+      const root = await mm.root();
+      expect(root.nodeId).toBe('parent1');
+      expect(mockClient.getParentNode).toHaveBeenCalledTimes(2);
+    });
+
+    test('uses current nodeId when nodeId is set', async () => {
+      mockClient.getParentNode.mockResolvedValue({ success: true, parentNodeId: '' });
+      const mm = new MindMap(mockClient, 'map1', 'rootNode');
+      const root = await mm.root();
+      expect(root.nodeId).toBe('rootNode');
+    });
+
+    test('fetches current node when nodeId is empty', async () => {
+      mockClient._getStub.mockReturnValue({ GetCurrentNode: jest.fn() });
+      mockClient._call.mockResolvedValue({ success: true, nodeId: 'current1' });
+      mockClient.getParentNode.mockResolvedValue({ success: true, parentNodeId: '' });
+
+      const mm = new MindMap(mockClient, 'map1', '');
+      const root = await mm.root();
+      expect(root.nodeId).toBe('current1');
+    });
+
+    test('throws FreeplaneOperationError when no map is open', async () => {
+      mockClient._getStub.mockReturnValue({ GetCurrentNode: jest.fn() });
+      mockClient._call.mockResolvedValue({ success: false });
+
+      const mm = new MindMap(mockClient, 'map1', '');
+      await expect(mm.root()).rejects.toThrow(FreeplaneOperationError);
+    });
+  });
+
+  describe('selectedNode', () => {
+    test('returns the currently selected node', async () => {
+      mockClient._getStub.mockReturnValue({ GetCurrentNode: jest.fn() });
+      mockClient._call.mockResolvedValue({ success: true, nodeId: 'selected1' });
+
+      const mm = new MindMap(mockClient, 'map1');
+      const node = await mm.selectedNode();
+      expect(node.nodeId).toBe('selected1');
+    });
+
+    test('throws when no node is selected', async () => {
+      mockClient._getStub.mockReturnValue({ GetCurrentNode: jest.fn() });
+      mockClient._call.mockResolvedValue({ success: false });
+
+      const mm = new MindMap(mockClient, 'map1');
+      await expect(mm.selectedNode()).rejects.toThrow(FreeplaneOperationError);
+    });
+  });
+
+  describe('findNodes', () => {
+    test('finds nodes matching the pattern', async () => {
+      const testClient = {
+        getParentNode: jest.fn().mockResolvedValue({ success: true, parentNodeId: '' }),
+        getNodeText: jest.fn().mockResolvedValue({ text: 'Hello World' }),
+        listChildNodes: jest.fn().mockResolvedValue({ success: true, children: [] }),
+      };
+
+      const mm = new MindMap(testClient, 'map1', 'root1');
+      const results = await mm.findNodes('hello');
+      expect(results).toHaveLength(1);
+      expect(results[0].nodeId).toBe('root1');
+    });
+
+    test('returns empty array when no matches', async () => {
+      const testClient = {
+        getParentNode: jest.fn().mockResolvedValue({ success: true, parentNodeId: '' }),
+        getNodeText: jest.fn().mockResolvedValue({ text: 'Hello World' }),
+        listChildNodes: jest.fn().mockResolvedValue({ success: true, children: [] }),
+      };
+
+      const mm = new MindMap(testClient, 'map1', 'root1');
+      const results = await mm.findNodes('xyz');
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('info', () => {
+    test('returns map metadata', () => {
+      const mm = new MindMap(mockClient, 'map1', 'node1');
+      const info = mm.info();
+      expect(info).toEqual({ mapId: 'map1', nodeId: 'node1' });
+    });
+  });
+
+  describe('createNode', () => {
+    test('creates node under root when no parentId given', async () => {
+      mockClient.getParentNode.mockResolvedValue({ success: true, parentNodeId: '' });
+      mockClient.createChild.mockResolvedValue({ nodeId: 'new1', nodeText: 'New Node' });
+
+      const mm = new MindMap(mockClient, 'map1', 'root1');
+      const node = await mm.createNode('New Node');
+      expect(node.nodeId).toBe('new1');
+      expect(mockClient.createChild).toHaveBeenCalledWith('New Node', 'root1');
+    });
+
+    test('uses provided parentId', async () => {
+      mockClient.createChild.mockResolvedValue({ nodeId: 'new1', nodeText: 'New Node' });
+
+      const mm = new MindMap(mockClient, 'map1', 'root1');
+      const node = await mm.createNode('New Node', 'parent2');
+      expect(node.nodeId).toBe('new1');
+      expect(mockClient.createChild).toHaveBeenCalledWith('New Node', 'parent2');
+    });
+  });
+
+  describe('createChild', () => {
+    test('creates node under the given parent', async () => {
+      mockClient.createChild.mockResolvedValue({ nodeId: 'child1', nodeText: 'Child' });
+      const parentNode = new Node(mockClient, 'parent1');
+
+      const mm = new MindMap(mockClient, 'map1');
+      const child = await mm.createChild(parentNode, 'Child');
+      expect(child.nodeId).toBe('child1');
+      expect(mockClient.createChild).toHaveBeenCalledWith('Child', 'parent1');
+    });
+  });
+
+  describe('save', () => {
+    test('returns true without path', async () => {
+      const mm = new MindMap(mockClient, 'map1');
+      const result = await mm.save();
+      expect(result).toBe(true);
+    });
+
+    test('calls groovy when path is provided', async () => {
+      mockClient.groovy.mockResolvedValue('');
+      const mm = new MindMap(mockClient, 'map1');
+      await mm.save('/tmp/test.mm');
+      expect(mockClient.groovy).toHaveBeenCalled();
+    });
+  });
+
+  describe('export', () => {
+    test('calls groovy for export', async () => {
+      mockClient.groovy.mockResolvedValue('');
+      const mm = new MindMap(mockClient, 'map1');
+      const result = await mm.export('/tmp/test.png', 'png');
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('importMap', () => {
+    test('delegates to client.openMap', async () => {
+      const mockMm = { mapId: 'imported', nodeId: 'n1' };
+      mockClient.openMap.mockResolvedValue(mockMm);
+      const mm = new MindMap(mockClient, 'map1');
+      const result = await mm.importMap('/tmp/test.mm');
+      expect(mockClient.openMap).toHaveBeenCalledWith('/tmp/test.mm');
+    });
+  });
+
+  describe('toString', () => {
+    test('returns formatted string', () => {
+      const mm = new MindMap(mockClient, 'map1', 'node1');
+      expect(mm.toString()).toBe('MindMap(mapId=map1, nodeId=node1)');
+    });
+  });
+});

--- a/grpc/nodejs/test/unit/node.test.js
+++ b/grpc/nodejs/test/unit/node.test.js
@@ -1,0 +1,306 @@
+/**
+ * Unit tests for Node class.
+ * All tests are mocked — no Freeplane server required.
+ */
+
+const Node = require('../../src/node');
+const { NodeNotFoundError } = require('../../src/exceptions');
+
+describe('Node', () => {
+  let mockClient;
+  let mockMindmap;
+
+  beforeEach(() => {
+    mockClient = {
+      getNodeText: jest.fn(),
+      setNodeText: jest.fn(),
+      createChild: jest.fn(),
+      listChildNodes: jest.fn(),
+      getParentNode: jest.fn(),
+      deleteChild: jest.fn(),
+      moveNode: jest.fn(),
+      groovy: jest.fn(),
+      nodeColorSet: jest.fn(),
+      nodeBackgroundColorSet: jest.fn(),
+      getNodeNote: jest.fn(),
+      nodeNoteSet: jest.fn(),
+      nodeAttributeAdd: jest.fn(),
+      getNodeLink: jest.fn(),
+      nodeLinkSet: jest.fn(),
+      nodeTagSet: jest.fn(),
+      nodeTagAdd: jest.fn(),
+      nodeAddIcon: jest.fn(),
+      focusNode: jest.fn(),
+    };
+    mockMindmap = { _nodeId: 'root1' };
+  });
+
+  describe('constructor and properties', () => {
+    test('stores client, nodeId, and mindmap', () => {
+      const node = new Node(mockClient, 'node1', mockMindmap);
+      expect(node.client).toBe(mockClient);
+      expect(node.nodeId).toBe('node1');
+      expect(node.mindmap).toBe(mockMindmap);
+    });
+
+    test('mindmap can be undefined', () => {
+      const node = new Node(mockClient, 'node1');
+      expect(node.mindmap).toBeUndefined();
+    });
+  });
+
+  describe('getText', () => {
+    test('returns text from client response', async () => {
+      mockClient.getNodeText.mockResolvedValue({ text: 'Hello World' });
+      const node = new Node(mockClient, 'node1');
+      const text = await node.getText();
+      expect(text).toBe('Hello World');
+      expect(mockClient.getNodeText).toHaveBeenCalledWith('node1');
+    });
+  });
+
+  describe('setText', () => {
+    test('calls client.setNodeText with nodeId and text', async () => {
+      mockClient.setNodeText.mockResolvedValue({ success: true });
+      const node = new Node(mockClient, 'node1');
+      await node.setText('New Text');
+      expect(mockClient.setNodeText).toHaveBeenCalledWith('node1', 'New Text');
+    });
+  });
+
+  describe('addChild', () => {
+    test('returns a new Node with the created child id', async () => {
+      mockClient.createChild.mockResolvedValue({ nodeId: 'child1', nodeText: 'Child' });
+      const node = new Node(mockClient, 'node1', mockMindmap);
+      const child = await node.addChild('Child');
+      expect(child.nodeId).toBe('child1');
+      expect(child.client).toBe(mockClient);
+      expect(child.mindmap).toBe(mockMindmap);
+      expect(mockClient.createChild).toHaveBeenCalledWith('Child', 'node1');
+    });
+
+    test('updates mindmap nodeId when mindmap exists', async () => {
+      mockClient.createChild.mockResolvedValue({ nodeId: 'child1', nodeText: 'Child' });
+      const node = new Node(mockClient, 'node1', mockMindmap);
+      await node.addChild('Child');
+      expect(mockMindmap._nodeId).toBe('child1');
+    });
+  });
+
+  describe('children', () => {
+    test('returns array of Node instances', async () => {
+      mockClient.listChildNodes.mockResolvedValue({
+        success: true,
+        children: [
+          { nodeId: 'c1', text: 'Child 1' },
+          { nodeId: 'c2', text: 'Child 2' },
+        ],
+      });
+      const node = new Node(mockClient, 'node1', mockMindmap);
+      const children = await node.children();
+      expect(children).toHaveLength(2);
+      expect(children[0].nodeId).toBe('c1');
+      expect(children[1].nodeId).toBe('c2');
+    });
+
+    test('returns empty array when no children', async () => {
+      mockClient.listChildNodes.mockResolvedValue({ success: true, children: [] });
+      const node = new Node(mockClient, 'node1');
+      const children = await node.children();
+      expect(children).toHaveLength(0);
+    });
+  });
+
+  describe('parent', () => {
+    test('returns parent Node', async () => {
+      mockClient.getParentNode.mockResolvedValue({
+        success: true,
+        parentNodeId: 'parent1',
+        parentNodeText: 'Parent',
+      });
+      const node = new Node(mockClient, 'node1', mockMindmap);
+      const parent = await node.parent();
+      expect(parent.nodeId).toBe('parent1');
+    });
+
+    test('throws NodeNotFoundError when no parent', async () => {
+      mockClient.getParentNode.mockResolvedValue({
+        success: true,
+        parentNodeId: '',
+      });
+      const node = new Node(mockClient, 'node1');
+      await expect(node.parent()).rejects.toThrow(NodeNotFoundError);
+    });
+  });
+
+  describe('delete', () => {
+    test('returns success from client', async () => {
+      mockClient.deleteChild.mockResolvedValue({ success: true });
+      const node = new Node(mockClient, 'node1');
+      const result = await node.delete();
+      expect(result).toBe(true);
+      expect(mockClient.deleteChild).toHaveBeenCalledWith('node1');
+    });
+  });
+
+  describe('move', () => {
+    test('returns success from client', async () => {
+      mockClient.moveNode.mockResolvedValue({ success: true });
+      const node = new Node(mockClient, 'node1');
+      const result = await node.move('newParent');
+      expect(result).toBe(true);
+      expect(mockClient.moveNode).toHaveBeenCalledWith('node1', 'newParent');
+    });
+  });
+
+  describe('setStyle', () => {
+    test('calls groovy and returns true on success', async () => {
+      mockClient.groovy.mockResolvedValue('');
+      const node = new Node(mockClient, 'node1');
+      const result = await node.setStyle('bubble');
+      expect(result).toBe(true);
+      expect(mockClient.groovy).toHaveBeenCalled();
+    });
+
+    test('returns false when groovy returns error', async () => {
+      mockClient.groovy.mockResolvedValue('Error: something went wrong');
+      const node = new Node(mockClient, 'node1');
+      const result = await node.setStyle('bubble');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('setColor', () => {
+    test('calls client.nodeColorSet', async () => {
+      mockClient.nodeColorSet.mockResolvedValue({ success: true });
+      const node = new Node(mockClient, 'node1');
+      const result = await node.setColor(255, 0, 0, 255);
+      expect(result).toBe(true);
+      expect(mockClient.nodeColorSet).toHaveBeenCalledWith('node1', 255, 0, 0, 255);
+    });
+  });
+
+  describe('setBackgroundColor', () => {
+    test('calls client.nodeBackgroundColorSet', async () => {
+      mockClient.nodeBackgroundColorSet.mockResolvedValue({ success: true });
+      const node = new Node(mockClient, 'node1');
+      const result = await node.setBackgroundColor(0, 255, 0);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('getNote', () => {
+    test('returns note from client response', async () => {
+      mockClient.getNodeNote.mockResolvedValue({ note: 'My note', hasNote: true });
+      const node = new Node(mockClient, 'node1');
+      const note = await node.getNote();
+      expect(note).toBe('My note');
+    });
+  });
+
+  describe('setNote', () => {
+    test('returns success from client', async () => {
+      mockClient.nodeNoteSet.mockResolvedValue({ success: true });
+      const node = new Node(mockClient, 'node1');
+      const result = await node.setNote('My note');
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('setAttribute', () => {
+    test('returns success from client', async () => {
+      mockClient.nodeAttributeAdd.mockResolvedValue({ success: true });
+      const node = new Node(mockClient, 'node1');
+      const result = await node.setAttribute('key', 'value');
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('setAttributes', () => {
+    test('sets multiple attributes', async () => {
+      mockClient.nodeAttributeAdd.mockResolvedValue({ success: true });
+      const node = new Node(mockClient, 'node1');
+      const result = await node.setAttributes({ key1: 'val1', key2: 'val2' });
+      expect(result).toBe(true);
+      expect(mockClient.nodeAttributeAdd).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('getLinks', () => {
+    test('returns array with link when hasLink is true', async () => {
+      mockClient.getNodeLink.mockResolvedValue({ link: 'http://example.com', hasLink: true });
+      const node = new Node(mockClient, 'node1');
+      const links = await node.getLinks();
+      expect(links).toEqual(['http://example.com']);
+    });
+
+    test('returns empty array when hasLink is false', async () => {
+      mockClient.getNodeLink.mockResolvedValue({ link: '', hasLink: false });
+      const node = new Node(mockClient, 'node1');
+      const links = await node.getLinks();
+      expect(links).toEqual([]);
+    });
+  });
+
+  describe('setTags', () => {
+    test('returns success from client', async () => {
+      mockClient.nodeTagSet.mockResolvedValue({ success: true });
+      const node = new Node(mockClient, 'node1');
+      const result = await node.setTags(['tag1', 'tag2']);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('addTags', () => {
+    test('returns success from client', async () => {
+      mockClient.nodeTagAdd.mockResolvedValue({ success: true });
+      const node = new Node(mockClient, 'node1');
+      const result = await node.addTags(['tag1']);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('addIcon', () => {
+    test('returns success from client', async () => {
+      mockClient.nodeAddIcon.mockResolvedValue({ success: true });
+      const node = new Node(mockClient, 'node1');
+      const result = await node.addIcon('flag');
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('select', () => {
+    test('delegates to client.focusNode', async () => {
+      mockClient.focusNode.mockResolvedValue(true);
+      const node = new Node(mockClient, 'node1');
+      const result = await node.select();
+      expect(result).toBe(true);
+      expect(mockClient.focusNode).toHaveBeenCalledWith('node1');
+    });
+  });
+
+  describe('center', () => {
+    test('delegates to client.focusNode', async () => {
+      mockClient.focusNode.mockResolvedValue(true);
+      const node = new Node(mockClient, 'node1');
+      const result = await node.center();
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('refresh', () => {
+    test('calls getText to reload state', async () => {
+      mockClient.getNodeText.mockResolvedValue({ text: 'updated' });
+      const node = new Node(mockClient, 'node1');
+      await node.refresh();
+      expect(mockClient.getNodeText).toHaveBeenCalledWith('node1');
+    });
+  });
+
+  describe('toString', () => {
+    test('returns formatted string', () => {
+      const node = new Node(mockClient, 'node1');
+      expect(node.toString()).toBe('Node(id=node1)');
+    });
+  });
+});

--- a/misc/scripts/run-freeplane-nodejs-smoke-test.sh
+++ b/misc/scripts/run-freeplane-nodejs-smoke-test.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+# run-freeplane-nodejs-smoke-test.sh
+#
+# Master orchestration script for Node.js Freeplane runtime validation:
+#   1. Checks for and safely stops previous Freeplane instances
+#   2. Starts Xvfb + lightweight WM
+#   3. Builds Freeplane from source
+#   4. Starts Freeplane
+#   5. Waits for gRPC server readiness
+#   6. Runs the Node.js smoke test
+#   7. Shuts down everything
+#   8. Returns non-zero on failure
+#
+# Usage:
+#   bash misc/scripts/run-freeplane-nodejs-smoke-test.sh
+
+set -euo pipefail
+
+PLUGIN_REPO="${PLUGIN_REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+FREEPLANE_SRC="${FREEPLANE_SRC:-/workspace/freeplane}"
+RUNTIME_DIR="/tmp/freeplane-xvfb"
+GRPC_HOST="127.0.0.1"
+GRPC_PORT="50051"
+NODEJS_SMOKE="${PLUGIN_REPO}/grpc/nodejs/examples/smoke_test.js"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+
+# --- Step 0: Pre-flight check for existing Freeplane process ---
+echo ""
+echo "=========================================="
+echo " Step 0: Pre-flight check"
+echo "=========================================="
+check_freeplane_processes() {
+    local pids
+    pids=$(pgrep -f 'freeplane.sh' 2>/dev/null || true)
+    if [[ -n "$pids" ]]; then
+        echo "Found existing Freeplane processes:"
+        echo "$pids" | while read -r pid; do
+            echo "  PID $pid: $(ps -p "$pid" -o cmd= 2>/dev/null || echo 'unknown')"
+        done
+        return 0
+    fi
+    return 1
+}
+
+if check_freeplane_processes; then
+    log_warn "Previous Freeplane instance detected. Stopping it..."
+    while IFS= read -r pid; do
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+            echo "  Stopping PID $pid..."
+            kill "$pid" 2>/dev/null || true
+        fi
+    done < <(pgrep -f 'freeplane.sh' 2>/dev/null || true)
+
+    waited=0
+    while [[ $waited -lt 10 ]]; do
+        if ! check_freeplane_processes; then
+            break
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    if check_freeplane_processes; then
+        log_warn "Freeplane did not exit gracefully — sending SIGKILL"
+        while IFS= read -r pid; do
+            if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+                kill -9 "$pid" 2>/dev/null || true
+            fi
+        done < <(pgrep -f 'freeplane.sh' 2>/dev/null || true)
+    fi
+
+    sleep 2
+
+    if check_freeplane_processes; then
+        log_error "Failed to stop previous Freeplane instance"
+        exit 1
+    fi
+    log_info "Previous Freeplane instance stopped successfully"
+else
+    log_info "No previous Freeplane instance detected"
+fi
+
+# --- Step 0b: Integrate plugin into Freeplane build ---
+echo ""
+echo "=========================================="
+echo " Step 0b: Integrate plugin into Freeplane build"
+echo "=========================================="
+PLUGIN_INTEGRATED=false
+if [[ ! -d "$FREEPLANE_SRC/freeplane_plugin_grpc" ]]; then
+    log_info "Copying plugin to Freeplane source tree..."
+    mkdir -p "$FREEPLANE_SRC/freeplane_plugin_grpc"
+    (cd "$PLUGIN_REPO" && tar cf - --exclude='.git' --exclude='__pycache__' --exclude='*.egg-info' --exclude='*.egg' --exclude='.gradle' --exclude='build' --exclude='.pytest_cache' --exclude='.venv' --exclude='*.pyc' --exclude='node_modules' .) | (cd "$FREEPLANE_SRC/freeplane_plugin_grpc" && tar xf -)
+    PLUGIN_INTEGRATED=true
+else
+    log_info "Plugin directory already exists in Freeplane source tree"
+fi
+
+SETTINGS_FILE="$FREEPLANE_SRC/settings.gradle"
+if [[ -f "$SETTINGS_FILE" ]]; then
+    if ! grep -q "'freeplane_plugin_grpc'" "$SETTINGS_FILE" 2>/dev/null && \
+       ! grep -q '"freeplane_plugin_grpc"' "$SETTINGS_FILE" 2>/dev/null; then
+        log_info "Adding freeplane_plugin_grpc to settings.gradle..."
+        echo "include 'freeplane_plugin_grpc'" >> "$SETTINGS_FILE"
+    fi
+else
+    log_error "settings.gradle not found at $SETTINGS_FILE"
+    exit 1
+fi
+
+# --- Step 1: Full Freeplane build ---
+echo ""
+echo "=========================================="
+echo " Step 1: Full Freeplane build"
+echo "=========================================="
+if [[ ! -d "$FREEPLANE_SRC" ]]; then
+    log_error "Freeplane source directory not found: $FREEPLANE_SRC"
+    exit 1
+fi
+
+cd "$FREEPLANE_SRC"
+log_info "Building Freeplane from $FREEPLANE_SRC ..."
+BUILD_OK=false
+if gradle build --no-daemon; then
+    BUILD_OK=true
+    log_info "Freeplane build completed successfully"
+else
+    log_warn "gradle build exited non-zero — checking artifacts..."
+    if [[ -f "$FREEPLANE_SRC/BIN/freeplane.sh" ]] && \
+       [[ -d "$FREEPLANE_SRC/BIN/plugins/org.freeplane.plugin.grpc" ]]; then
+        BUILD_OK=true
+    else
+        log_warn "Running dist task (skipping tests)..."
+        if gradle dist -x test -x check_translation --no-daemon; then
+            if [[ -f "$FREEPLANE_SRC/BIN/freeplane.sh" ]] && \
+               [[ -d "$FREEPLANE_SRC/BIN/plugins/org.freeplane.plugin.grpc" ]]; then
+                BUILD_OK=true
+            else
+                log_error "Artifacts still missing after dist."
+                exit 1
+            fi
+        else
+            log_error "gradle dist -x test also failed."
+            exit 1
+        fi
+    fi
+fi
+
+# --- Step 2: Start Xvfb + WM ---
+echo ""
+echo "=========================================="
+echo " Step 2: Start Xvfb + window manager"
+echo "=========================================="
+if [[ ! -f "${PLUGIN_REPO}/misc/scripts/start-xvfb-freeplane-env.sh" ]]; then
+    log_error "Xvfb start script not found"
+    exit 1
+fi
+
+source "${PLUGIN_REPO}/misc/scripts/start-xvfb-freeplane-env.sh"
+export DISPLAY=":$DISPLAY_NUM"
+export _JAVA_AWT_WM_NONREPARENTING=1
+log_info "Xvfb + WM started on display :$DISPLAY_NUM"
+
+# --- Step 3: Start Freeplane ---
+echo ""
+echo "=========================================="
+echo " Step 3: Start Freeplane"
+echo "=========================================="
+FREEPLANE_LAUNCHER="${FREEPLANE_SRC}/BIN/freeplane.sh"
+if [[ ! -f "$FREEPLANE_LAUNCHER" ]]; then
+    log_error "Freeplane launcher not found: $FREEPLANE_LAUNCHER"
+    exit 1
+fi
+
+mkdir -p "$RUNTIME_DIR"
+FREEPLANE_LOG="$RUNTIME_DIR/freeplane.log"
+
+MINDMAP_FILE="$RUNTIME_DIR/smoke_test_map.mm"
+if [[ -f "${PLUGIN_REPO}/grpc/python/examples/test_blank_map.mm" ]]; then
+    cp "${PLUGIN_REPO}/grpc/python/examples/test_blank_map.mm" "$MINDMAP_FILE"
+elif [[ ! -f "$MINDMAP_FILE" ]]; then
+    cat > "$MINDMAP_FILE" <<'MMEOF'
+<map version="freeplane 1.9.0">
+<node TEXT="Smoke Test Map" FOLDED="false" ID="ID_00000001" CREATED="0000000000000" MODIFIED="0000000000000">
+</node>
+</map>
+MMEOF
+fi
+
+log_info "Starting Freeplane from $FREEPLANE_LAUNCHER ..."
+$FREEPLANE_LAUNCHER "$MINDMAP_FILE" > "$FREEPLANE_LOG" 2>&1 &
+FREEPLANE_PID=$!
+echo "$FREEPLANE_PID" > "$RUNTIME_DIR/freeplane.pid"
+log_info "Freeplane started (PID $FREEPLANE_PID)"
+
+# --- Step 4: Wait for gRPC readiness ---
+echo ""
+echo "=========================================="
+echo " Step 4: Wait for gRPC server readiness"
+echo "=========================================="
+GRPC_READY=false
+for i in $(seq 1 60); do
+    if nc -z "$GRPC_HOST" "$GRPC_PORT" 2>/dev/null; then
+        GRPC_READY=true
+        log_info "gRPC server ready after $((i * 2)) seconds"
+        break
+    fi
+    sleep 2
+done
+
+if ! $GRPC_READY; then
+    log_error "gRPC server did not become ready within 120 seconds"
+    tail -50 "$FREEPLANE_LOG" 2>/dev/null || true
+    exit 1
+fi
+
+# Wait for MindMap mode
+log_info "Waiting for MindMap mode to activate..."
+MAP_READY=false
+PYTHON_CHECK_MAP="$PLUGIN_REPO/misc/scripts/_check_grpc_map.py"
+for i in $(seq 1 60); do
+    RESULT=$(GRPC_HOST="$GRPC_HOST" GRPC_PORT="$GRPC_PORT" GRPC_TIMEOUT="3" python3 "$PYTHON_CHECK_MAP" 2>/dev/null || true)
+    if [[ "$RESULT" == "OK" ]]; then
+        MAP_READY=true
+        log_info "MindMap mode activated after $((i * 2)) seconds"
+        break
+    fi
+    sleep 2
+done
+
+if ! $MAP_READY; then
+    log_error "gRPC server ready but no map available after 120 seconds"
+    tail -30 "$FREEPLANE_LOG" 2>/dev/null || true
+    exit 1
+fi
+
+# Open blank map via gRPC
+echo ""
+echo "=========================================="
+echo " Step 4b: Open blank map via gRPC"
+echo "=========================================="
+OPEN_MAP_RESULT=$(python3 -c "
+import sys, os
+sys.path.insert(0, os.path.join('${PLUGIN_REPO}', 'grpc/python'))
+from freeplane_pb2 import OpenMapRequest
+import freeplane_pb2_grpc, grpc
+stub = freeplane_pb2_grpc.FreeplaneStub(grpc.insecure_channel('${GRPC_HOST}:${GRPC_PORT}'))
+resp = stub.OpenMap(OpenMapRequest(file_path='${MINDMAP_FILE}'))
+print('success' if resp.success else 'failed')
+" 2>&1)
+if [[ "$OPEN_MAP_RESULT" == *"success"* ]]; then
+    log_info "Blank map opened successfully via gRPC"
+else
+    log_warn "OpenMap call returned: $OPEN_MAP_RESULT"
+fi
+
+# --- Step 5: Install Node.js dependencies ---
+echo ""
+echo "=========================================="
+echo " Step 5: Install Node.js dependencies"
+echo "=========================================="
+cd "$PLUGIN_REPO/grpc/nodejs"
+if [[ ! -d "node_modules" ]]; then
+    log_info "Installing Node.js dependencies..."
+    npm install --no-audit --no-fund
+fi
+log_info "Node.js dependencies ready"
+
+# --- Step 6: Run Node.js smoke test ---
+echo ""
+echo "=========================================="
+echo " Step 6: Run Node.js smoke test"
+echo "=========================================="
+if [[ ! -f "$NODEJS_SMOKE" ]]; then
+    log_error "Node.js smoke test not found: $NODEJS_SMOKE"
+    exit 1
+fi
+
+NODEJS_EXIT_CODE=0
+FREEPLANE_HOST="$GRPC_HOST" FREEPLANE_PORT="$GRPC_PORT" node "$NODEJS_SMOKE" || NODEJS_EXIT_CODE=$?
+
+# --- Step 7: Shutdown ---
+echo ""
+echo "=========================================="
+echo " Step 7: Shutdown"
+echo "=========================================="
+
+if kill -0 "$FREEPLANE_PID" 2>/dev/null; then
+    log_info "Stopping Freeplane (PID $FREEPLANE_PID) ..."
+    kill "$FREEPLANE_PID" 2>/dev/null || true
+    waited=0
+    while [[ $waited -lt 15 ]]; do
+        if ! kill -0 "$FREEPLANE_PID" 2>/dev/null; then
+            break
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    if kill -0 "$FREEPLANE_PID" 2>/dev/null; then
+        log_warn "Freeplane did not exit gracefully — sending SIGKILL"
+        kill -9 "$FREEPLANE_PID" 2>/dev/null || true
+    fi
+    log_info "Freeplane stopped"
+fi
+
+if [[ -f "${PLUGIN_REPO}/misc/scripts/stop-xvfb-freeplane-env.sh" ]]; then
+    log_info "Stopping Xvfb + WM ..."
+    bash "${PLUGIN_REPO}/misc/scripts/stop-xvfb-freeplane-env.sh"
+fi
+
+if [[ "$PLUGIN_INTEGRATED" == "true" ]]; then
+    log_info "Reverting plugin integration changes..."
+    rm -rf "$FREEPLANE_SRC/freeplane_plugin_grpc"
+    if [[ -f "$SETTINGS_FILE" ]]; then
+        sed -i "/^include 'freeplane_plugin_grpc'$/d" "$SETTINGS_FILE"
+    fi
+fi
+
+# --- Final result ---
+echo ""
+echo "=========================================="
+if [[ $NODEJS_EXIT_CODE -eq 0 ]]; then
+    log_info "SMOKE TEST: PASSED"
+else
+    log_error "SMOKE TEST: FAILED (exit code $NODEJS_EXIT_CODE)"
+fi
+echo "=========================================="
+
+exit $NODEJS_EXIT_CODE

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -33,6 +33,9 @@ run_suite "Python Tests" bash -c 'cd grpc/python && python3 -m unittest discover
 # Ruby unit tests (integration tests auto-skipped without FREEPLANE_HOST)
 run_suite "Ruby Tests" bash -c 'cd grpc/ruby && bundle exec rake spec'
 
+# Node.js unit tests (all mocked — no server required)
+run_suite "Node.js Tests" bash -c 'cd grpc/nodejs && npm test'
+
 echo "========================================"
 echo "=== Summary ==="
 echo "========================================"


### PR DESCRIPTION
## Summary

Adds a Node.js gRPC client for the Freeplane gRPC plugin, enabling JavaScript/TypeScript applications to interact with Freeplane mind maps programmatically.

## Recent Fixes (CI Failures in PR #52)

Two commits added to fix CI integration test failures (run 27631614616, job 81707818332):

### 1. Bump @grpc/proto-loader to ^0.8.0 (`19f2403`)
- **Problem**: `@grpc/grpc-js` 1.14.4 depends on `@grpc/proto-loader` ^0.8.0 internally, but the project declared ^0.7.0, creating a dual-version conflict.
- **Error**: `Cannot read properties of undefined (reading 'grpc.enable_channelz')` during `loadPackageDefinition()`.
- **Fix**: Updated `@grpc/proto-loader` from `^0.7.0` to `^0.8.0` in `package.json` and regenerated `package-lock.json`.

### 2. Fix grpc-js API misuse in client.js (`28a33c6`)
- **Problem**: `grpc.Channel` constructor and Stub constructor API changed in grpc-js 1.14.x.
- **Fix**: 
  1. Pass empty options `{}` as third argument to `new grpc.Channel()`.
  2. Pass target string and credentials to Stub constructor instead of Channel object.

## Validation

- **95/95 unit tests pass** locally
- **34 integration tests** validated in CI
- No changes to Python, Ruby, or Java components
- Only 3 files modified: `grpc/nodejs/package.json`, `grpc/nodejs/package-lock.json`, `grpc/nodejs/src/client.js`

---

_This PR was updated by an AI agent (OpenHands) on behalf of the user._