### PR TITLE
docs: update README.md and add Rust client README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 3. [Examples](#examples)
 
-    3.1 [Ruby](#example_python)
+    3.1 [Ruby](#example_ruby)
 
-    3.2 [Python](#example_ruby)
+    3.2 [Python](#example_python)
 
     3.3 [Shell (grpcurl)](#example_shell)
 
@@ -18,7 +18,7 @@
 
     5.2 [Build plugin](#build_plugin)
 
-    5.2 [Add new gRPC function](#add_new_grpc_function)
+    5.3 [Add new gRPC function](#add_new_grpc_function)
 
 6. [Limitations of the current implementation](#limitation)
 
@@ -31,7 +31,7 @@
   The Freeplane plugin for gRPC allows you to start a gRPC server within a running instance of Freeplane. By default, the gRPC server listens on port 50051 and waits for gRPC calls from clients. You can change this behavior by specifying the `GRPC_LISTEN_ADDR` and `GRPC_LISTEN_PORT` environment variables.
 
 
-  [Protobuf file](https://github.com/metacoma/freeplane_plugin_grpc/blob/ca8f667a0f373506c579762c92ffd954ca1827c7/src/main/proto/freeplane.proto)
+  [Protobuf file](https://github.com/metacoma/freeplane_plugin_grpc/blob/main/src/main/proto/freeplane.proto)
 
   The Protocol Buffer file describes the protocol for interaction between gRPC clients and servers.
 
@@ -39,7 +39,11 @@
 
   The pre-built libraries for Python and Ruby, based on the Protocol Buffer file, make it easy to get started with these programming languages.
 
-  Examples for [python](https://github.com/metacoma/freeplane_plugin_grpc/blob/main/grpc/python/freeplane_ec2.py), [ruby](https://github.com/metacoma/freeplane_plugin_grpc/blob/ca8f667a0f373506c579762c92ffd954ca1827c7/grpc/ruby/pomodoro.rb) and [shell](https://github.com/metacoma/freeplane_plugin_grpc/blob/ca8f667a0f373506c579762c92ffd954ca1827c7/grpc/shell/grpcurl_test.sh)
+  Examples for [Node.js](https://github.com/metacoma/freeplane_plugin_grpc/tree/main/grpc/nodejs) and [Rust](https://github.com/metacoma/freeplane_plugin_grpc/tree/main/grpc/rust)
+
+  Object-oriented client libraries (Client, MindMap, Node) are available for Python, Ruby, Node.js, and Rust.
+
+  Examples for [python](https://github.com/metacoma/freeplane_plugin_grpc/blob/main/grpc/python/freeplane_ec2.py), [ruby](https://github.com/metacoma/freeplane_plugin_grpc/blob/main/grpc/ruby/pomodoro.rb) and [shell](https://github.com/metacoma/freeplane_plugin_grpc/blob/main/grpc/shell/grpcurl_test.sh)
 
   The repository also includes simple examples of gRPC clients written in Shell, Python, and Ruby.
 
@@ -75,7 +79,7 @@ With freeplane_grpc_plugin you can use your preferred programming language to en
 
   *  [Ruby](https://grpc.io/docs/languages/ruby/)
 
-**<a id="exampels">3. Examples</a>**
+**<a id="examples">3. Examples</a>**
 
   You can find ruby,python and shell examples in [grpc](https://github.com/metacoma/freeplane_plugin_grpc/tree/main/grpc) directory.
 
@@ -188,17 +192,42 @@ $ bash ./grpcurl_test.sh
 
   ![image](https://github.com/metacoma/freeplane_plugin_grpc/blob/main/misc/grpc_plugin.png?raw=true)
 
-  At this moment, Freeplane plugin gRPC provides following API (this is part of protobuf definition, the full protobuf file you can find  [here](https://github.com/metacoma/freeplane_plugin_grpc/blob/ca8f667a0f373506c579762c92ffd954ca1827c7/src/main/proto/freeplane.proto)
+  At this moment, Freeplane plugin gRPC provides the following 27 RPC methods (full protobuf definition [here](https://github.com/metacoma/freeplane_plugin_grpc/blob/main/src/main/proto/freeplane.proto)):
+
 ```
 service Freeplane {
+  // Core operations
   rpc CreateChild (CreateChildRequest) returns (CreateChildResponse) {};
   rpc DeleteChild (DeleteChildRequest) returns (DeleteChildResponse) {};
   rpc NodeAttributeAdd (NodeAttributeAddRequest) returns (NodeAttributeAddResponse) {};
   rpc NodeLinkSet (NodeLinkSetRequest) returns (NodeLinkSetResponse) {};
   rpc NodeDetailsSet (NodeDetailsSetRequest) returns (NodeDetailsSetResponse) {};
-  rpc Groovy (GroovyRequest) returns (GroovyResponse) {}; // not ready
+  rpc NodeNoteSet (NodeNoteSetRequest) returns (NodeNoteSetResponse) {};
+  rpc NodeTagSet (NodeTagSetRequest) returns (NodeTagSetResponse) {};
+  rpc NodeTagAdd (NodeTagAddRequest) returns (NodeTagAddResponse) {};
+  rpc NodeConnect (NodeConnectRequest) returns (NodeConnectResponse) {};
+  rpc NodeAddIcon (NodeAddIconRequest) returns (NodeAddIconResponse) {};
+  rpc Groovy (GroovyRequest) returns (GroovyResponse) {};
   rpc NodeColorSet (NodeColorSetRequest) returns (NodeColorSetResponse) {};
   rpc NodeBackgroundColorSet (NodeBackgroundColorSetRequest) returns (NodeBackgroundColorSetResponse) {};
+  rpc StatusInfoSet (StatusInfoSetRequest) returns (StatusInfoSetResponse) {};
+  rpc TextFSM (TextFSMRequest) returns (TextFSMResponse) {};
+  rpc MindMapFromJSON (MindMapFromJSONRequest) returns (MindMapFromJSONResponse) {};
+  rpc MindMapToJSON (MindMapToJSONRequest) returns (MindMapToJSONResponse) {};
+  rpc GetCurrentNode (GetCurrentNodeRequest) returns (GetCurrentNodeResponse) {};
+  rpc OpenMap (OpenMapRequest) returns (OpenMapResponse) {};
+  rpc FocusNode (FocusNodeRequest) returns (FocusNodeResponse) {};
+
+  // Group A: Node Inspection
+  rpc GetNodeText (GetNodeTextRequest) returns (GetNodeTextResponse) {};
+  rpc GetParentNode (GetParentNodeRequest) returns (GetParentNodeResponse) {};
+  rpc ListChildNodes (ListChildNodesRequest) returns (ListChildNodesResponse) {};
+  rpc GetNodeNote (GetNodeNoteRequest) returns (GetNodeNoteResponse) {};
+  rpc GetNodeLink (GetNodeLinkRequest) returns (GetNodeLinkResponse) {};
+
+  // Group B: Node Manipulation
+  rpc SetNodeText (SetNodeTextRequest) returns (SetNodeTextResponse) {};
+  rpc MoveNode (MoveNodeRequest) returns (MoveNodeResponse) {};
 }
 ```
 
@@ -213,7 +242,7 @@ service Freeplane {
 
 **<a id="quick_start">5. Quick start</a>**
 
-**<a id="install_plugin>">5.1 Install plugin</a>**
+**<a id="install_plugin">5.1 Install plugin</a>**
 
   Install pre-built plugin from [Release](https://github.com/metacoma/freeplane_plugin_grpc/releases) GitHub page.
 
@@ -257,7 +286,7 @@ Freeplane grpc plugin loaded and listen 50051 port
 
  1. Define a new gRPC service in the protobuf file.
 
- Open [main/src/main/proto/freeplane.proto](https://github.com/metacoma/freeplane_plugin_grpc/blob/main/src/main/proto/freeplane.proto) file in your favorite text editor and add the new StatusInfoSet function definition in the service section.
+ Open [src/main/proto/freeplane.proto](https://github.com/metacoma/freeplane_plugin_grpc/blob/main/src/main/proto/freeplane.proto) file in your favorite text editor and add the new StatusInfoSet function definition in the service section.
 
 ```
 service Freeplane {
@@ -280,7 +309,7 @@ message StatusInfoSetResponse {
 //Add this import in the import section in the head of the
 import org.freeplane.features.ui.ViewController;
 //.......
-// Add statusInfoSet public java method inside class FreeplaneImpl definition
+// Add statusInfoSet public java method inside class FreeplaneGrpcService definition
                 @Override
                 public void statusInfoSet(StatusInfoSetRequest req, StreamObserver<StatusInfoSetResponse> responseObserver) {
                         boolean success = false;
@@ -353,10 +382,8 @@ stub.status_info_set(Freeplane::StatusInfoSetRequest.new(statusInfo: "hello from
 
   * This plugin is under active development, and the gRPC API may change.
 
-  * gRPC TCP server port 50051 is hardcoded https://github.com/metacoma/freeplane_plugin_grpc/blob/ca8f667a0f373506c579762c92ffd954ca1827c7/src/main/java/org/freeplane/plugin/grpc/GrpcRegistration.java#L59-L65
+  * The gRPC server listens on port 50051 by default, but this can be configured via the `GRPC_LISTEN_PORT` environment variable (and `GRPC_LISTEN_ADDR` for the bind address). See [GrpcRegistration.java](https://github.com/metacoma/freeplane_plugin_grpc/blob/main/src/main/java/org/freeplane/plugin/grpc/GrpcRegistration.java).
 
   * Sometimes Freeplane throws a [Java exception](https://github.com/metacoma/freeplane_plugin_grpc/issues/1), possibly due to race conditions or other factors.
-
-  * gRPC groovy function have a stub and not implemented yet https://github.com/metacoma/freeplane_plugin_grpc/blob/ca8f667a0f373506c579762c92ffd954ca1827c7/src/main/java/org/freeplane/plugin/grpc/GrpcRegistration.java#L183-L196
 
   * This plugin I have tested only on the Linux. However, I don't anticipate any issues with it working on other operating systems.

--- a/grpc/rust/README.md
+++ b/grpc/rust/README.md
@@ -1,0 +1,112 @@
+# freeplane-grpc (Rust)
+
+Rust gRPC client for the [Freeplane](https://www.freeplane.org/) mind-map application.
+
+## Requirements
+
+- Rust 1.70+ (edition 2021)
+- Freeplane with the gRPC plugin enabled (default port: 50051)
+
+## Installation
+
+```bash
+cd grpc/rust
+cargo build
+```
+
+Or add as a dependency in your `Cargo.toml`:
+
+```toml
+[dependencies]
+freeplane-grpc = { git = "https://github.com/metacoma/freeplane_plugin_grpc", branch = "main" }
+```
+
+## Usage
+
+```rust
+use freeplane_grpc::FreeplaneClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut client = FreeplaneClient::connect("127.0.0.1", 50051).await?;
+
+    let mindmap = client.mind_map();
+    let root = mindmap.root().await?;
+    println!("Root: {}", root.get_text().await?);
+
+    let child = root.add_child("Hello from Rust", "").await?;
+    child.set_text("Modified text").await?;
+    child.set_note("A note").await?;
+
+    client.close().await;
+    Ok(())
+}
+```
+
+## Configuration
+
+| Environment Variable | Default     | Description              |
+|---------------------|-------------|--------------------------|
+| `GRPC_LISTEN_ADDR`  | `0.0.0.0`   | Freeplane gRPC server bind address |
+| `GRPC_LISTEN_PORT`  | `50051`     | Freeplane gRPC server port |
+
+## API
+
+### FreeplaneClient
+
+- `connect(host, port)` — Open gRPC channel
+- `close()` — Close gRPC channel
+- `current_map()` — Get the current mind map
+- `open_map(filePath)` — Open a .mm file
+- `get_map_to_json()` — Export current map as JSON
+- `mind_map_from_json(json)` — Import map from JSON
+- `groovy(code)` — Execute Groovy code on the server
+- `focus_node(nodeId)` — Focus a node in the UI
+- `status_info_set(info)` — Set status bar text
+- `text_fsm(json)` — Process JSON through TextFSM
+- `mind_map()` — Create a `MindMap` instance
+- `node(node_id)` — Create a `Node` instance
+
+### Node
+
+- `get_text()` / `set_text(text)`
+- `add_child(text, style)` / `children()` / `parent()` / `delete()` / `move_to(new_parent_id)`
+- `get_note()` / `set_note(note)`
+- `get_attributes()` / `set_attribute(name, value)` / `set_attributes(attrs)`
+- `get_links()` / `set_links(links)`
+- `set_tags(tags)` / `add_tags(tags)`
+- `add_icon(icon_name)`
+- `set_color(r, g, b, a)` / `set_background_color(r, g, b, a)`
+- `select()` / `center()` / `refresh()`
+- `get_style()` / `set_style(style)`
+
+### MindMap
+
+- `root()` — Get the root node
+- `selected_node()` — Get the currently selected node
+- `find_nodes(pattern)` — Search nodes by text
+- `create_node(text, parent_id, style)` / `create_child(parent, text, style)`
+- `info()` / `size()`
+- `save(path)` / `export(path, format)` / `import_map(path)`
+
+### Error Types
+
+- `FreeplaneGrpcError` — Base error
+- `FreeplaneConnectionError` — Connection/network failures
+- `FreeplaneOperationError` — Server-reported operation failures
+- `NodeNotFoundError` — Requested node does not exist
+- `MindMapError` — Map-level operation failures
+
+## Testing
+
+```bash
+# Unit tests (mocked, no server required)
+cargo test
+
+# Integration tests (requires running Freeplane with gRPC plugin)
+cargo test --test integration
+```
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

This PR addresses all 9 README inaccuracies identified in the architect plan and adds a new Rust client README.

### README.md Fixes

1. **TOC anchor swap** — Fixed Ruby → `#example_ruby`, Python → `#example_python`
2. **Duplicate section numbering** — Fixed 5.2 → 5.3 for "Add new gRPC function"
3. **API listing expanded** — All 27 RPC methods from `freeplane.proto` now listed, grouped as Core / Node Inspection / Node Manipulation
4. **Client mentions** — Added Node.js and Rust client links alongside Python and Ruby
5. **Stale commit hashes** — All 5 `ca8f667...` references replaced with `main` branch links
6. **Typo fix** — `exampels` → `examples`
7. **Anchor fix** — `install_plugin>` → `install_plugin` (removed extra quote)
8. **Port limitation** — Updated to reflect `GRPC_LISTEN_PORT` / `GRPC_LISTEN_ADDR` env vars (not hardcoded)
9. **Groovy stub removed** — Groovy RPC method is fully implemented in `FreeplaneGrpcService.java`
10. **Tutorial updated** — Section 5.3 now references `FreeplaneGrpcService` instead of removed `FreeplaneImpl`

### New Files

- **`grpc/rust/README.md`** — Rust client documentation following the established pattern from `grpc/nodejs/README.md` and `grpc/python/README.md`, covering FreeplaneClient, Node, and MindMap APIs.

### Validation

- Proto RPC count: 27 ✅
- README RPC count: 27 ✅
- No stale commit hashes ✅
- No "hardcoded" or "stub" references ✅
- Python tests: 70/70 PASS ✅
- Node.js tests: 95/95 PASS ✅