### PR TITLE
docs: add Installation section (Section 0) with OS-specific instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
+0. [Installation](#installation)
+
+    0.1 [From GitHub Releases](#installation_from_github_releases)
+
+        0.1.1 [Linux (binary zip)](#linux_binary_zip)
+
+        0.1.2 [macOS (binary zip)](#macos_binary_zip)
+
+        0.1.3 [macOS (DMG .app)](#macos_dmg)
+
+        0.1.4 [Windows (binary zip, PowerShell)](#windows_binary_zip)
+
+        0.1.5 [Windows (installer)](#windows_installer)
+
+        0.1.6 [Linux (deb package)](#linux_deb)
+
+    0.2 [Building from Source](#building_from_source)
+
+    0.3 [Verification (Smoke Tests)](#verification)
+
 1. [Introduction](#introduction)
 
 2. [gRPC](#grpc)
@@ -23,6 +43,178 @@
     5.3 [Add new gRPC function](#add_new_grpc_function)
 
 6. [Limitations of the current implementation](#limitation)
+
+**<a id="installation">0. Installation</a>**
+
+  Install the gRPC plugin for Freeplane using one of the methods below.
+
+  **Prerequisites:** Freeplane **1.13.2** (or later) installed on your system. Binary zip distributions require **Java 11–21** (Java 8 on Linux). Native installers (DMG, Windows Installer, deb) embed Java.
+
+---
+
+**<a id="installation_from_github_releases">0.1 From GitHub Releases</a>**
+
+  Download the plugin from the [latest release](https://github.com/metacoma/freeplane_plugin_grpc/releases/tag/0.1.0).
+
+  > **Note:** The release artifact filename contains a typo: `org.freplane.plugin.grpc` (missing "p" in "freeplane"). All URLs and commands below use the actual filename.
+
+**<a id="linux_binary_zip">0.1.1 Linux (binary zip)</a>**
+
+```bash
+# Download Freeplane and plugin, extract, install, and verify
+FREEPLANE_VERSION=1.13.2 && PLUGIN_VERSION=0.1.0 && \
+curl -sL "https://github.com/freeplane/freeplane/releases/download/release-${FREEPLANE_VERSION}/freeplane_bin-${FREEPLANE_VERSION}.zip" -o /tmp/freeplane.zip && \
+mkdir -p /tmp/freeplane && unzip -q /tmp/freeplane.zip -d /tmp/freeplane && rm /tmp/freeplane.zip && \
+curl -sL "https://github.com/metacoma/freeplane_plugin_grpc/releases/download/${PLUGIN_VERSION}/org.freplane.plugin.grpc.tar.gz" -o /tmp/plugin.tar.gz && \
+tar xzf /tmp/plugin.tar.gz -C /tmp/freeplane/freeplane-${FREEPLANE_VERSION}/plugins/ && \
+echo "Plugin installed. Start Freeplane: /tmp/freeplane/freeplane-${FREEPLANE_VERSION}/freeplane.sh"
+```
+
+**<a id="macos_binary_zip">0.1.2 macOS (binary zip)</a>**
+
+```bash
+# Download Freeplane and plugin, extract, install, and verify
+FREEPLANE_VERSION=1.13.2 && PLUGIN_VERSION=0.1.0 && \
+curl -sL "https://github.com/freeplane/freeplane/releases/download/release-${FREEPLANE_VERSION}/freeplane_bin-${FREEPLANE_VERSION}.zip" -o /tmp/freeplane.zip && \
+mkdir -p /tmp/freeplane && unzip -q /tmp/freeplane.zip -d /tmp/freeplane && rm /tmp/freeplane.zip && \
+curl -sL "https://github.com/metacoma/freeplane_plugin_grpc/releases/download/${PLUGIN_VERSION}/org.freplane.plugin.grpc.tar.gz" -o /tmp/plugin.tar.gz && \
+tar xzf /tmp/plugin.tar.gz -C /tmp/freeplane/freeplane-${FREEPLANE_VERSION}/plugins/ && \
+echo "Plugin installed. Start Freeplane: /tmp/freeplane/freeplane-${FREEPLANE_VERSION}/freeplane.sh"
+```
+
+**<a id="macos_dmg">0.1.3 macOS (DMG .app)</a>**
+
+  1. Install Freeplane via DMG (double-click the `.dmg` file and drag to `/Applications/`).
+  2. Download the plugin:
+
+```bash
+PLUGIN_VERSION=0.1.0 && \
+curl -sL "https://github.com/metacoma/freeplane_plugin_grpc/releases/download/${PLUGIN_VERSION}/org.freplane.plugin.grpc.tar.gz" -o /tmp/plugin.tar.gz && \
+tar xzf /tmp/plugin.tar.gz -C /Applications/Freeplane.app/Contents/app/plugins/
+```
+
+  > **Note:** You may need `sudo` to write to `/Applications/`. Alternatively, copy `.app` to `~/Applications/` first to avoid permission issues.
+
+**<a id="windows_binary_zip">0.1.4 Windows (binary zip, PowerShell)</a>**
+
+```powershell
+# Download Freeplane and plugin, extract, install, and verify
+$FreeplaneVersion = "1.13.2"; $PluginVersion = "0.1.0";
+Invoke-WebRequest -Uri "https://github.com/freeplane/freeplane/releases/download/release-${FreeplaneVersion}/freeplane_bin-${FreeplaneVersion}.zip" -OutFile "$env:TEMP\freeplane.zip";
+Expand-Archive -Path "$env:TEMP\freeplane.zip" -DestinationPath "$env:TEMP\freeplane" -Force; Remove-Item "$env:TEMP\freeplane.zip";
+Invoke-WebRequest -Uri "https://github.com/metacoma/freeplane_plugin_grpc/releases/download/${PluginVersion}/org.freplane.plugin.grpc.tar.gz" -OutFile "$env:TEMP\plugin.tar.gz";
+tar xzf "$env:TEMP\plugin.tar.gz" -C "$env:TEMP\freeplane\freeplane-${FreeplaneVersion}\plugins\";
+Write-Host "Plugin installed. Start Freeplane: $env:TEMP\freeplane\freeplane-${FreeplaneVersion}\freeplane.bat"
+```
+
+**<a id="windows_installer">0.1.5 Windows (installer)</a>**
+
+  1. Run the Freeplane installer (`Freeplane-Setup-1.13.2.exe`).
+  2. Download the plugin and extract to the plugins directory:
+
+```powershell
+$PluginVersion = "0.1.0";
+Invoke-WebRequest -Uri "https://github.com/metacoma/freeplane_plugin_grpc/releases/download/${PluginVersion}/org.freplane.plugin.grpc.tar.gz" -OutFile "$env:TEMP\plugin.tar.gz";
+tar xzf "$env:TEMP\plugin.tar.gz" -C "C:\Program Files\Freeplane\plugins\";
+```
+
+  > **Note:** Admin privileges may be required to write to `C:\Program Files\Freeplane\`. The binary zip approach (above) does not require admin rights.
+
+**<a id="linux_deb">0.1.6 Linux (deb package)</a>**
+
+  1. Install the deb package:
+
+```bash
+wget "https://github.com/freeplane/freeplane/releases/download/release-1.13.2/freeplane_1.13.2.upstream-1_all.deb" -O /tmp/freeplane.deb
+sudo dpkg -i /tmp/freeplane.deb
+```
+
+  2. Download and install the plugin:
+
+```bash
+PLUGIN_VERSION=0.1.0 && \
+curl -sL "https://github.com/metacoma/freeplane_plugin_grpc/releases/download/${PLUGIN_VERSION}/org.freplane.plugin.grpc.tar.gz" -o /tmp/plugin.tar.gz && \
+sudo tar xzf /tmp/plugin.tar.gz -C /usr/share/freeplane/plugins/
+```
+
+---
+
+**<a id="building_from_source">0.2 Building from Source</a>**
+
+  For developers who want to build the plugin from source.
+
+  **Prerequisites:** Java 11+, Gradle, Git.
+
+```bash
+# 1. Clone Freeplane 1.13.x source
+git clone --branch 1.13.x https://github.com/freeplane/freeplane.git
+cd freeplane
+
+# 2. Clone this plugin repository
+git clone https://github.com/metacoma/freeplane_plugin_grpc
+
+# 3. Add plugin as a subproject
+echo "include 'freeplane_plugin_grpc'" >> settings.gradle
+
+# 4. Build the plugin
+cd freeplane_plugin_grpc
+gradle :freeplane_plugin_grpc:build --no-daemon
+
+# 5. Install the built plugin into Freeplane
+#    The Gradle build produces the OSGi plugin structure in BIN/plugins/org.freeplane.plugin.grpc/
+#    Copy to your Freeplane installation's plugins directory:
+#    cp -r BIN/plugins/org.freeplane.plugin.grpc <FREEPLANE_INSTALL_DIR>/plugins/
+
+# 6. Start Freeplane
+cd ..
+./freeplane-1.13.2/freeplane.sh   # or your Freeplane install path
+
+# Verify: look for log line "Freeplane grpc plugin loaded and listen 50051 port"
+# Verify gRPC: nc -z 127.0.0.1 50051
+```
+
+---
+
+**<a id="verification">0.3 Verification (Smoke Tests)</a>**
+
+  After installation (from release or from source), verify the plugin works:
+
+  1. **Start Freeplane** with the plugin installed.
+  2. **Check gRPC port**:
+
+```bash
+nc -z 127.0.0.1 50051 && echo "gRPC server is listening"
+```
+
+  3. **Run Python smoke test**:
+
+```bash
+python3 grpc/python/examples/modify_mindmap_example.py
+```
+
+  4. **Run Node.js smoke test**:
+
+```bash
+cd grpc/nodejs && npm ci && npx jest --testPathPattern=test/integration
+```
+
+  5. **Run Ruby smoke test**:
+
+```bash
+cd grpc/ruby && bundle exec rspec spec/integration/
+```
+
+  6. **Run unit tests** (no Freeplane required):
+
+```bash
+bash scripts/run-tests.sh
+```
+
+  For a fully automated end-to-end smoke test:
+
+```bash
+bash misc/scripts/run-freeplane-python-smoke-test.sh
+```
 
 **<a id="introduction">1. Introduction</a>**
 


### PR DESCRIPTION
## Summary

Adds a new **Section 0 — Installation** at the beginning of README.md, covering:

### 0.1 From GitHub Releases
- **0.1.1** Linux (binary zip) — with bash one-liner
- **0.1.2** macOS (binary zip) — with bash one-liner
- **0.1.3** macOS (DMG .app) — with sudo/permission notes
- **0.1.4** Windows (binary zip, PowerShell) — with PowerShell one-liner
- **0.1.5** Windows (installer) — with admin privilege notes
- **0.1.6** Linux (deb package)

### 0.2 Building from Source
- Step-by-step instructions matching the CI workflow (`.github/workflows/integration.yml`)
- Prerequisites: Java 11+, Gradle, Git

### 0.3 Verification (Smoke Tests)
- gRPC port check (`nc -z 127.0.0.1 50051`)
- Python, Node.js, Ruby, and unit test commands
- Reference to automated smoke test script

## Key Details
- Freeplane version referenced: **1.13.2**
- Plugin release version: **0.1.0**
- Artifact filename typo noted: `org.freplane.plugin.grpc` (missing "p")
- Java prerequisites specified for binary zip distributions
- Table of Contents updated with all new section anchors

## Validation Evidence
- **QA (qa-1)**: All 3 download URLs live, one-liner dry-run succeeded, unit tests pass (Python 70/70, Node.js 95/95, Rust 123/123). Freeplane GUI smoke tests blocked by sandbox (no Xvfb/display).
- **Reviewer (reviewer-1)**: All 10 TOC anchors match headers, all 3 download URLs live (HTTP 302), all 5 referenced file paths exist, build-from-source instructions match CI workflow.

## Files Changed
- `README.md` — +192 lines (new Section 0 Installation + TOC update)